### PR TITLE
issue #149 update urls in nuspec files

### DIFF
--- a/GitDepend.Commandline.nuspec
+++ b/GitDepend.Commandline.nuspec
@@ -6,11 +6,11 @@
     <title>GitDepend.CommandLine</title>
     <authors>kjjuno and Contributors</authors>
     <owners>kjjuno and Contributors</owners>
-    <licenseUrl>https://github.com/kjjuno/GitDepend/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/kjjuno/GitDepend</projectUrl>
+    <licenseUrl>https://github.com/GitDepend/GitDepend/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/GitDepend/GitDepend</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A tool to handle dependency trees with multiple git repositories without using submodules.</description>
-    <releaseNotes>https://github.com/kjjuno/GitDepend/releases</releaseNotes>
+    <releaseNotes>https://github.com/GitDepend/GitDepend/releases</releaseNotes>
     <copyright>Copyright 2017</copyright>
     <tags>Git Submodules Subtree GitVersion Dependency Repository Repo</tags>
     <developmentDependency>true</developmentDependency>

--- a/GitDepend.Portable.nuspec
+++ b/GitDepend.Portable.nuspec
@@ -6,11 +6,11 @@
     <title>GitDepend</title>
     <authors>kjjuno and Contributors</authors>
     <owners>kjjuno and Contributors</owners>
-    <licenseUrl>https://github.com/kjjuno/GitDepend/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/kjjuno/GitDepend</projectUrl>
+    <licenseUrl>https://github.com/GitDepend/GitDepend/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/GitDepend/GitDepend</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A tool to handle dependency trees with multiple git repositories without using submodules.</description>
-    <releaseNotes>https://github.com/kjjuno/GitDepend/releases</releaseNotes>
+    <releaseNotes>https://github.com/GitDepend/GitDepend/releases</releaseNotes>
     <copyright>Copyright 2017</copyright>
     <tags>Git Submodules Subtree GitVersion Dependency Repository Repo</tags>
   </metadata>

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Simple setup for the sole purpose of reservering names on github.com and nuget.o
 
 [gitter]:          https://badges.gitter.im/GitDepend/Lobby.svg
 [gitter-badge]:    https://gitter.im/GitDepend/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
-[appveyor]:        https://ci.appveyor.com/project/kjjuno/gitdepend/branch/develop
-[appveyor-badge]:  https://ci.appveyor.com/api/projects/status/github/kjjuno/GitDepend?branch=develop&svg=true
+[appveyor]:        https://ci.appveyor.com/project/gitdepend/gitdepend/branch/develop
+[appveyor-badge]:  https://ci.appveyor.com/api/projects/status/github/gitdepend/GitDepend?branch=develop&svg=true
 [docs]:            http://gitdepend.readthedocs.org/en/stable/
 [docs-badge]:      https://readthedocs.org/projects/gitdepend/badge/?version=stable
 [docs-pre]:        http://gitdepend.readthedocs.org/en/latest/
 [docs-pre-badge]:  https://readthedocs.org/projects/gitdepend/badge/?version=latest
-[gh-rel]:          https://github.com/kjjuno/GitDepend/releases/latest
-[gh-rel-badge]:    https://img.shields.io/github/release/kjjuno/gitdepend.svg
+[gh-rel]:          https://github.com/gitdepend/GitDepend/releases/latest
+[gh-rel-badge]:    https://img.shields.io/github/release/gitdepend/gitdepend.svg
 [choco]:           https://chocolatey.org/packages/GitDepend.Portable
 [choco-badge]:     https://img.shields.io/chocolatey/v/gitepend.portable.svg
 [choco-pre-badge]: https://img.shields.io/chocolatey/vpre/gitdepend.portable.svg

--- a/docs/source/usage_example.rst
+++ b/docs/source/usage_example.rst
@@ -15,7 +15,7 @@ In the root of your repository you will include a ``GitDepend.json`` file
       },
       "dependencies": [
         {
-          "url": "git@github.com:kjjuno/Lib1.git",
+          "url": "git@github.com:GitDepend/Lib1.git",
           "dir": "../Lib1",
           "branch": "develop"
         }
@@ -44,8 +44,8 @@ Try it out!
 
 Take a look at some example projects and try it out for yourself.
 
-* `Lib1 <https://github.com/kjjuno/Lib1/>`_
-* `Lib2 <https://github.com/kjjuno/Lib2/>`_
+* `Lib1 <https://github.com/GitDepend/Lib1/>`_
+* `Lib2 <https://github.com/GitDepend/Lib2/>`_
 
 Lib2 depends on Lib1
 
@@ -53,7 +53,7 @@ Clone Lib2
 
 .. code-block:: bash
 
-    git clone git@github.com:kjjuno/Lib2.git
+    git clone git@github.com:GitDepend/Lib2.git
 
 from the root of Lib2 run
 


### PR DESCRIPTION
Why:

* GitDepend was recently moved to the GitDepend organization. Several links now need to be updated to reflect this change.

This change addresses the need by:

* Updating the links in the nuspec files.