### PR TITLE
issue #161 fixes the arguments parsing for nuget

### DIFF
--- a/GitDepend.UnitTests/Visitors/BuildAndUpdateDependenciesVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/BuildAndUpdateDependenciesVisitorTests.cs
@@ -189,7 +189,7 @@ namespace GitDepend.UnitTests.Visitors
             fileSystem.Directory.Arrange(d => d.GetFiles(Arg.AnyString, "*.nupkg"))
                 .Returns(Lib1Packages.ToArray());
             fileSystem.Directory.Arrange(d => d.GetFiles(Arg.AnyString, "*.sln", Arg.IsAny<SearchOption>()))
-                .Returns(Lib2Solutions.ToArray());
+                .Returns(Lib2Solutions.Select(s => Lib2Directory + "\\" + s).ToArray());
 
             fileSystem.Path.Arrange(p => p.GetFileNameWithoutExtension(Arg.AnyString))
                 .Returns(Path.GetFileNameWithoutExtension);

--- a/GitDepend/Busi/Nuget.cs
+++ b/GitDepend/Busi/Nuget.cs
@@ -2,7 +2,9 @@
 using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace GitDepend.Busi
 {
@@ -54,7 +56,12 @@ namespace GitDepend.Busi
 
             StringBuilder sb = new StringBuilder();
             Console.SetOut(new StringWriter(sb));
-            var code = NuGet.CommandLine.Program.Main(arguments.Split());
+            var args = Regex.Matches(arguments, @"[\""].+?[\""]|[^ ]+")
+                .Cast<Match>()
+                .Select(m => m.Value.Trim('"'))
+                .ToArray();
+
+            var code = NuGet.CommandLine.Program.Main(args);
 
             Console.SetOut(oldOut);
             

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -182,6 +182,9 @@ namespace GitDepend.Visitors
 
             foreach (var solution in solutions)
             {
+                var path = solution.Remove(0, directory.Length + 1);
+                commitMessage.AppendLine(path);
+
                 foreach (var dependency in config.Dependencies)
                 {
                     // If there are specific dependencies specified


### PR DESCRIPTION
Why:

* arguments wrapped in quotes were incorrectly handled

This change addresses the need by:

* uses a more intelligent parsing routine to group arguments wrapped in
quotes.
* Also addresses #162 (commit message should specify which solution was
updated)