### PR TITLE
issue #169 Update now returns FailedToRunNugetCommand

### DIFF
--- a/GitDepend/Busi/Nuget.cs
+++ b/GitDepend/Busi/Nuget.cs
@@ -47,7 +47,7 @@ namespace GitDepend.Busi
         /// <returns>The nuget return code.</returns>
         public ReturnCode Update(string soluton, string id, string version, string sourceDirectory)
         {
-            return ExecuteNuGetCommand($"update {soluton} -Id {id} -Version {version} -Source \"{sourceDirectory}\" -Pre");
+            return ExecuteNuGetCommand($"update {soluton} -Id {id} -Version {version} -Source \"{sourceDirectory}\" -Pre -verbosity quiet");
         }
 
         private ReturnCode ExecuteNuGetCommand(string arguments)
@@ -62,10 +62,17 @@ namespace GitDepend.Busi
                 .ToArray();
 
             var code = NuGet.CommandLine.Program.Main(args);
-
+            var output = sb.ToString();
+            var hasWarnings = output.ToLower().Contains("warning");
+            
             Console.SetOut(oldOut);
             
             _console.WriteLine($"nuget {arguments}");
+            if (hasWarnings)
+            {
+                _console.WriteLine(output);
+                code = 3;
+            }
 
             return code != (int)ReturnCode.Success
                 ? ReturnCode.FailedToRunNugetCommand

--- a/GitDepend/Busi/Nuget.cs
+++ b/GitDepend/Busi/Nuget.cs
@@ -14,6 +14,7 @@ namespace GitDepend.Busi
     public class Nuget : INuget
     {
         private readonly IConsole _console;
+        private const int ErrorEncountered = 1;
 
         /// <summary>
         /// The working directory for nuget.exe
@@ -71,7 +72,7 @@ namespace GitDepend.Busi
             if (hasWarnings)
             {
                 _console.WriteLine(output);
-                code = 3;
+                code = ErrorEncountered;
             }
 
             return code != (int)ReturnCode.Success

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -230,7 +230,11 @@ namespace GitDepend.Visitors
                             return ReturnCode = ReturnCode.CouldNotCreateCacheDirectory;
                         }
 
-                        _nuget.Update(solution, id, version, cacheDir);
+                        var returnCode = _nuget.Update(solution, id, version, cacheDir);
+                        if (returnCode != ReturnCode.Success)
+                        {
+                            return returnCode;
+                        }
 
                         var package = $"{id}.{version}";
                         if (!UpdatedPackages.Contains(package))

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -177,7 +177,11 @@ namespace GitDepend.Visitors
 
             foreach (var solution in solutions)
             {
-                _nuget.Restore(solution);
+                var returnCode = _nuget.Restore(solution);
+                if (returnCode != ReturnCode.Success)
+                {
+                    return returnCode;
+                }
             }
 
             foreach (var solution in solutions)


### PR DESCRIPTION
Why:

* Update doesn't fail when nuget fails to update a package

This change addresses the need by:

* Adding code to detect whether warnings are being thrown for being
unable to update