### PR TITLE
#177 moved console strings to resx strings file

### DIFF
--- a/GitDepend/Busi/DependencyExtensions.cs
+++ b/GitDepend/Busi/DependencyExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Busi
 {
@@ -47,7 +48,7 @@ namespace GitDepend.Busi
                 {
                     dep.Branch = branch;
                     dirty = true;
-                    Console.WriteLine($"using {dep.Branch} for {dep.Configuration.Name}");
+                    Console.WriteLine(strings.USING_BRANCH_FOR_CONFIG, dep.Branch, dep.Configuration.Name);
                 }
 
                 if (dirty)

--- a/GitDepend/Commands/BranchCommand.cs
+++ b/GitDepend/Commands/BranchCommand.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -78,7 +79,7 @@ namespace GitDepend.Commands
             if (_options.Delete)
             {
                 visitor = new DeleteBranchVisitor(_options.BranchName, _options.ForceDelete);
-                successMessage = $"Successfully deleted the {_options.BranchName} branch from all repositories.";
+                successMessage = string.Format(strings.SUCCESFULLY_DELETED_BRANCH_ALL_REPOS, _options.BranchName);
             }
             else if (_options.ListMerged)
             {
@@ -93,7 +94,7 @@ namespace GitDepend.Commands
             else if (!string.IsNullOrEmpty(_options.BranchName))
             {
                 visitor = new CreateBranchVisitor(_options.BranchName);
-                successMessage = $"Successfully created the {_options.BranchName} branch in all repositories.";
+                successMessage = string.Format(strings.SUCCESFULLY_CREATED_BRANCH_ALL_REPOS, _options.BranchName);
             }
             else
             {
@@ -113,8 +114,8 @@ namespace GitDepend.Commands
             {
                 var origColor = _console.ForegroundColor;
                 _console.ForegroundColor = ConsoleColor.Green;
-                _console.WriteLine("project:");
-                _console.WriteLine($"    dir: {_options.Directory}");
+                _console.WriteLine(strings.PROJECT);
+                _console.WriteLine(strings.DIRECTORY + _options.Directory);
                 _console.WriteLine();
                 _console.ForegroundColor = origColor;
 

--- a/GitDepend/Commands/CloneCommand.cs
+++ b/GitDepend/Commands/CloneCommand.cs
@@ -2,6 +2,7 @@
 using System.IO.Abstractions;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -44,7 +45,7 @@ namespace GitDepend.Commands
 
             if (visitor.ReturnCode == ReturnCode.Success)
             {
-                _console.WriteLine("Successfully cloned all dependencies");
+                _console.WriteLine(strings.CLONED_ALL_DEPS);
             }
 
             visitor = new CheckOutDependencyBranchVisitor();
@@ -53,7 +54,7 @@ namespace GitDepend.Commands
 
             if (visitor.ReturnCode == ReturnCode.Success)
             {
-                _console.WriteLine("All dependencies on the correct branch");
+                _console.WriteLine(strings.DEPS_CORRECT_BRANCH);
             }
 
             return visitor.ReturnCode;

--- a/GitDepend/Commands/NamedDependenciesCommand.cs
+++ b/GitDepend/Commands/NamedDependenciesCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -49,8 +50,8 @@ namespace GitDepend.Commands
             {
                 var origColor = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("project:");
-                Console.WriteLine($"    dir: {Options.Directory}");
+                Console.WriteLine(strings.PROJECT);
+                Console.WriteLine(strings.DIRECTORY + Options.Directory);
                 Console.WriteLine();
                 Console.ForegroundColor = origColor;
 

--- a/GitDepend/Commands/SyncCommand.cs
+++ b/GitDepend/Commands/SyncCommand.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -77,7 +78,7 @@ namespace GitDepend.Commands
                 {
                     dep.Branch = branch;
                     dirty = true;
-                    Console.WriteLine($"using {dep.Branch} for {dep.Configuration.Name}");
+                    Console.WriteLine(strings.USING_BRANCH_FOR_CONFIG,dep.Branch, dep.Configuration.Name);
                 }
             }
 

--- a/GitDepend/Commands/SyncCommand.cs
+++ b/GitDepend/Commands/SyncCommand.cs
@@ -78,7 +78,7 @@ namespace GitDepend.Commands
                 {
                     dep.Branch = branch;
                     dirty = true;
-                    Console.WriteLine(strings.USING_BRANCH_FOR_CONFIG,dep.Branch, dep.Configuration.Name);
+                    Console.WriteLine(strings.USING_BRANCH_FOR_CONFIG, dep.Branch, dep.Configuration.Name);
                 }
             }
 
@@ -87,7 +87,7 @@ namespace GitDepend.Commands
                 _fileSystem.File.WriteAllText(_fileSystem.Path.Combine(dir, "GitDepend.json"), config.ToString());
             }
 
-            Console.WriteLine($"all dependency branches synchronized successfully!");
+            Console.WriteLine(strings.SYNC_SUCCESS);
 
             return ReturnCode.Success;
         }

--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -3,6 +3,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -45,7 +46,7 @@ namespace GitDepend.Commands
 
             if (verifyVisitor.ReturnCode != ReturnCode.Success)
             {
-                _console.WriteLine("Not all dependencies are on the correct branch.");
+                _console.WriteLine(strings.NOT_ALL_DEPS_CORRECT_BRANCH);
                 return verifyVisitor.ReturnCode;
             }
 
@@ -58,16 +59,16 @@ namespace GitDepend.Commands
             {
                 if (buildAndUpdateVisitor.UpdatedPackages.Any())
                 {
-                    _console.WriteLine("Updated packages: ");
+                    _console.WriteLine(strings.UPDATED_PACKAGES);
                     foreach (var package in buildAndUpdateVisitor.UpdatedPackages)
                     {
                         _console.WriteLine($"    {package}");
                     }
-                    _console.WriteLine("Update complete!");
+                    _console.WriteLine(strings.UPDATE_COMPLETE);
                 }
                 else
                 {
-                    _console.WriteLine("nothing was updated");
+                    _console.WriteLine(strings.NOTHING_UPDATED);
                 }
             }
 

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -61,11 +61,47 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking out the {0} branch on {1}.
+        /// </summary>
+        internal static string CHECKING_OUT_BRANCH_ON_REPONAME {
+            get {
+                return ResourceManager.GetString("CHECKING_OUT_BRANCH_ON_REPONAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Successfully cloned all dependencies.
         /// </summary>
         internal static string CLONED_ALL_DEPS {
             get {
                 return ResourceManager.GetString("CLONED_ALL_DEPS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cloning {0} into {1}.
+        /// </summary>
+        internal static string CLONING_DEP_INTO_DIRECTORY {
+            get {
+                return ResourceManager.GetString("CLONING_DEP_INTO_DIRECTORY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creating the {0} branch on {1}.
+        /// </summary>
+        internal static string CREATING_BRANCH_ON_REPONAME {
+            get {
+                return ResourceManager.GetString("CREATING_BRANCH_ON_REPONAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to dependency:.
+        /// </summary>
+        internal static string DEPENDENCY {
+            get {
+                return ResourceManager.GetString("DEPENDENCY", resourceCulture);
             }
         }
         
@@ -93,6 +129,15 @@ namespace GitDepend.Resources {
         internal static string MAKING_UPDATE_COMMIT_ON {
             get {
                 return ResourceManager.GetString("MAKING_UPDATE_COMMIT_ON", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     name: .
+        /// </summary>
+        internal static string NAME {
+            get {
+                return ResourceManager.GetString("NAME", resourceCulture);
             }
         }
         

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -124,6 +124,42 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to     expected {0} but was {1}.
+        /// </summary>
+        internal static string EXPECTED_BRANCH_BUT_WAS_BRANCH {
+            get {
+                return ResourceManager.GetString("EXPECTED_BRANCH_BUT_WAS_BRANCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 3. Give up. I&apos;ll figure it out myself..
+        /// </summary>
+        internal static string GIVE_UP_OPTION {
+            get {
+                return ResourceManager.GetString("GIVE_UP_OPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid Branch!.
+        /// </summary>
+        internal static string INVALID_BRANCH {
+            get {
+                return ResourceManager.GetString("INVALID_BRANCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to everything looks good..
+        /// </summary>
+        internal static string LOOKS_GOOD {
+            get {
+                return ResourceManager.GetString("LOOKS_GOOD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Making update commit on .
         /// </summary>
         internal static string MAKING_UPDATE_COMMIT_ON {
@@ -304,6 +340,15 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 2. Switch branch to .
+        /// </summary>
+        internal static string SWITCH_BRANCH_OPTION {
+            get {
+                return ResourceManager.GetString("SWITCH_BRANCH_OPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to all dependency branches synchronized successfully!.
         /// </summary>
         internal static string SYNC_SUCCESS {
@@ -313,11 +358,29 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Huh? Try again..
+        /// </summary>
+        internal static string TRY_AGAIN {
+            get {
+                return ResourceManager.GetString("TRY_AGAIN", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Update complete!.
         /// </summary>
         internal static string UPDATE_COMPLETE {
             get {
                 return ResourceManager.GetString("UPDATE_COMPLETE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1. Update config to point to .
+        /// </summary>
+        internal static string UPDATE_CONFIG {
+            get {
+                return ResourceManager.GetString("UPDATE_CONFIG", resourceCulture);
             }
         }
         
@@ -336,6 +399,24 @@ namespace GitDepend.Resources {
         internal static string USING_BRANCH_FOR_CONFIG {
             get {
                 return ResourceManager.GetString("USING_BRANCH_FOR_CONFIG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Verifying the checked out branch.
+        /// </summary>
+        internal static string VERIFYING_CHECKED_OUT_BRANCH {
+            get {
+                return ResourceManager.GetString("VERIFYING_CHECKED_OUT_BRANCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What should I do?.
+        /// </summary>
+        internal static string WHAT_SHOULD_I_DO {
+            get {
+                return ResourceManager.GetString("WHAT_SHOULD_I_DO", resourceCulture);
             }
         }
     }

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -61,6 +61,69 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Successfully cloned all dependencies.
+        /// </summary>
+        internal static string CLONED_ALL_DEPS {
+            get {
+                return ResourceManager.GetString("CLONED_ALL_DEPS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All dependencies on the correct branch.
+        /// </summary>
+        internal static string DEPS_CORRECT_BRANCH {
+            get {
+                return ResourceManager.GetString("DEPS_CORRECT_BRANCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     dir: .
+        /// </summary>
+        internal static string DIRECTORY {
+            get {
+                return ResourceManager.GetString("DIRECTORY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Making update commit on .
+        /// </summary>
+        internal static string MAKING_UPDATE_COMMIT_ON {
+            get {
+                return ResourceManager.GetString("MAKING_UPDATE_COMMIT_ON", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not all dependencies are on the correct branch..
+        /// </summary>
+        internal static string NOT_ALL_DEPS_CORRECT_BRANCH {
+            get {
+                return ResourceManager.GetString("NOT_ALL_DEPS_CORRECT_BRANCH", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to nothing was updated.
+        /// </summary>
+        internal static string NOTHING_UPDATED {
+            get {
+                return ResourceManager.GetString("NOTHING_UPDATED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to project:.
+        /// </summary>
+        internal static string PROJECT {
+            get {
+                return ResourceManager.GetString("PROJECT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The build script failed.
         /// </summary>
         internal static string RET_BUILD_SCRIPT_FAILED {
@@ -174,6 +237,60 @@ namespace GitDepend.Resources {
         internal static string RET_UNKNOWN_ERROR {
             get {
                 return ResourceManager.GetString("RET_UNKNOWN_ERROR", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully created the {0} branch in all repositories..
+        /// </summary>
+        internal static string SUCCESFULLY_CREATED_BRANCH_ALL_REPOS {
+            get {
+                return ResourceManager.GetString("SUCCESFULLY_CREATED_BRANCH_ALL_REPOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully deleted the {0} branch in all repositories..
+        /// </summary>
+        internal static string SUCCESFULLY_DELETED_BRANCH_ALL_REPOS {
+            get {
+                return ResourceManager.GetString("SUCCESFULLY_DELETED_BRANCH_ALL_REPOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to all dependency branches synchronized successfully!.
+        /// </summary>
+        internal static string SYNC_SUCCESS {
+            get {
+                return ResourceManager.GetString("SYNC_SUCCESS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update complete!.
+        /// </summary>
+        internal static string UPDATE_COMPLETE {
+            get {
+                return ResourceManager.GetString("UPDATE_COMPLETE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updated packages: .
+        /// </summary>
+        internal static string UPDATED_PACKAGES {
+            get {
+                return ResourceManager.GetString("UPDATED_PACKAGES", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to using {0} for {1}.
+        /// </summary>
+        internal static string USING_BRANCH_FOR_CONFIG {
+            get {
+                return ResourceManager.GetString("USING_BRANCH_FOR_CONFIG", resourceCulture);
             }
         }
     }

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -138,6 +138,18 @@
   <data name="DIRECTORY" xml:space="preserve">
     <value>    dir: </value>
   </data>
+  <data name="EXPECTED_BRANCH_BUT_WAS_BRANCH" xml:space="preserve">
+    <value>    expected {0} but was {1}</value>
+  </data>
+  <data name="GIVE_UP_OPTION" xml:space="preserve">
+    <value>3. Give up. I'll figure it out myself.</value>
+  </data>
+  <data name="INVALID_BRANCH" xml:space="preserve">
+    <value>Invalid Branch!</value>
+  </data>
+  <data name="LOOKS_GOOD" xml:space="preserve">
+    <value>everything looks good.</value>
+  </data>
   <data name="MAKING_UPDATE_COMMIT_ON" xml:space="preserve">
     <value>Making update commit on </value>
   </data>
@@ -198,16 +210,31 @@
   <data name="SUCCESFULLY_DELETED_BRANCH_ALL_REPOS" xml:space="preserve">
     <value>Successfully deleted the {0} branch in all repositories.</value>
   </data>
+  <data name="SWITCH_BRANCH_OPTION" xml:space="preserve">
+    <value>2. Switch branch to </value>
+  </data>
   <data name="SYNC_SUCCESS" xml:space="preserve">
     <value>all dependency branches synchronized successfully!</value>
   </data>
-  <data name="UPDATE_COMPLETE">
+  <data name="TRY_AGAIN" xml:space="preserve">
+    <value>Huh? Try again.</value>
+  </data>
+  <data name="UPDATE_COMPLETE" xml:space="preserve">
     <value>Update complete!</value>
+  </data>
+  <data name="UPDATE_CONFIG" xml:space="preserve">
+    <value>1. Update config to point to </value>
   </data>
   <data name="UPDATED_PACKAGES" xml:space="preserve">
     <value>Updated packages: </value>
   </data>
   <data name="USING_BRANCH_FOR_CONFIG" xml:space="preserve">
     <value>using {0} for {1}</value>
+  </data>
+  <data name="VERIFYING_CHECKED_OUT_BRANCH" xml:space="preserve">
+    <value>Verifying the checked out branch</value>
+  </data>
+  <data name="WHAT_SHOULD_I_DO" xml:space="preserve">
+    <value>What should I do?</value>
   </data>
 </root>

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -117,8 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CHECKING_OUT_BRANCH_ON_REPONAME">
+    <value>Checking out the {0} branch on {1}</value>
+  </data>
   <data name="CLONED_ALL_DEPS" xml:space="preserve">
     <value>Successfully cloned all dependencies</value>
+  </data>
+  <data name="CLONING_DEP_INTO_DIRECTORY" xml:space="preserve">
+    <value>Cloning {0} into {1}</value>
+  </data>
+  <data name="CREATING_BRANCH_ON_REPONAME">
+    <value>Creating the {0} branch on {1}</value>
+  </data>
+  <data name="DEPENDENCY" xml:space="preserve">
+    <value>dependency:</value>
   </data>
   <data name="DEPS_CORRECT_BRANCH" xml:space="preserve">
     <value>All dependencies on the correct branch</value>
@@ -128,6 +140,9 @@
   </data>
   <data name="MAKING_UPDATE_COMMIT_ON" xml:space="preserve">
     <value>Making update commit on </value>
+  </data>
+  <data name="NAME" xml:space="preserve">
+    <value>    name: </value>
   </data>
   <data name="NOT_ALL_DEPS_CORRECT_BRANCH" xml:space="preserve">
     <value>Not all dependencies are on the correct branch.</value>

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -117,6 +117,27 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CLONED_ALL_DEPS" xml:space="preserve">
+    <value>Successfully cloned all dependencies</value>
+  </data>
+  <data name="DEPS_CORRECT_BRANCH" xml:space="preserve">
+    <value>All dependencies on the correct branch</value>
+  </data>
+  <data name="DIRECTORY" xml:space="preserve">
+    <value>    dir: </value>
+  </data>
+  <data name="MAKING_UPDATE_COMMIT_ON" xml:space="preserve">
+    <value>Making update commit on </value>
+  </data>
+  <data name="NOT_ALL_DEPS_CORRECT_BRANCH" xml:space="preserve">
+    <value>Not all dependencies are on the correct branch.</value>
+  </data>
+  <data name="NOTHING_UPDATED" xml:space="preserve">
+    <value>nothing was updated</value>
+  </data>
+  <data name="PROJECT" xml:space="preserve">
+    <value>project:</value>
+  </data>
   <data name="RET_BUILD_SCRIPT_FAILED" xml:space="preserve">
     <value>The build script failed</value>
   </data>
@@ -155,5 +176,23 @@
   </data>
   <data name="RET_UNKNOWN_ERROR" xml:space="preserve">
     <value>Unknown Error</value>
+  </data>
+  <data name="SUCCESFULLY_CREATED_BRANCH_ALL_REPOS" xml:space="preserve">
+    <value>Successfully created the {0} branch in all repositories.</value>
+  </data>
+  <data name="SUCCESFULLY_DELETED_BRANCH_ALL_REPOS" xml:space="preserve">
+    <value>Successfully deleted the {0} branch in all repositories.</value>
+  </data>
+  <data name="SYNC_SUCCESS" xml:space="preserve">
+    <value>all dependency branches synchronized successfully!</value>
+  </data>
+  <data name="UPDATE_COMPLETE">
+    <value>Update complete!</value>
+  </data>
+  <data name="UPDATED_PACKAGES" xml:space="preserve">
+    <value>Updated packages: </value>
+  </data>
+  <data name="USING_BRANCH_FOR_CONFIG" xml:space="preserve">
+    <value>using {0} for {1}</value>
   </data>
 </root>

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -250,7 +251,7 @@ namespace GitDepend.Visitors
             }
 
             _console.WriteLine("================================================================================");
-            _console.WriteLine($"Making update commit on {directory}");
+            _console.WriteLine(strings.MAKING_UPDATE_COMMIT_ON  + directory);
             _git.WorkingDirectory = directory;
             _git.Add("*.csproj", @"*\packages.config");
             _console.WriteLine("================================================================================");

--- a/GitDepend/Visitors/CheckOutDependencyBranchVisitor.cs
+++ b/GitDepend/Visitors/CheckOutDependencyBranchVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Abstractions;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -39,7 +40,7 @@ namespace GitDepend.Visitors
         /// <returns>The return code.</returns>
         public ReturnCode VisitDependency(string directory, Dependency dependency)
         {
-            _console.WriteLine($"Checking out the {dependency.Branch} branch on {dependency.Configuration.Name}");
+            _console.WriteLine(strings.CHECKING_OUT_BRANCH_ON_REPONAME, dependency.Branch, dependency.Configuration.Name);
 
             _git.WorkingDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(directory, dependency.Directory));
             return ReturnCode = _git.Checkout(dependency.Branch, false);

--- a/GitDepend/Visitors/CreateBranchVisitor.cs
+++ b/GitDepend/Visitors/CreateBranchVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -53,7 +54,7 @@ namespace GitDepend.Visitors
         /// <returns>The return code.</returns>
         public ReturnCode VisitProject(string directory, GitDependFile config)
         {
-            _console.WriteLine($"Creating the {BranchName} branch on {config.Name}");
+            _console.WriteLine(strings.CREATING_BRANCH_ON_REPONAME, BranchName, config.Name);
             _git.WorkingDirectory = directory;
             return ReturnCode = _git.CreateBranch(BranchName);
         }

--- a/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
+++ b/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO.Abstractions;
 using GitDepend.Busi;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -67,7 +68,7 @@ namespace GitDepend.Visitors
                 // If the dependency does not exist on disk we need to clone it.
                 if (!_fileSystem.Directory.Exists(dependency.Directory))
                 {
-                    _console.WriteLine($"Cloning {dependency.Url} into {dependency.Directory}");
+                    _console.WriteLine(strings.CLONING_DEP_INTO_DIRECTORY, dependency.Url, dependency.Directory);
 
                     code = _git.Clone(dependency.Url, dependency.Directory, dependency.Branch);
                     _console.WriteLine();

--- a/GitDepend/Visitors/ListAllBranchesVisitor.cs
+++ b/GitDepend/Visitors/ListAllBranchesVisitor.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO.Abstractions;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -43,9 +44,9 @@ namespace GitDepend.Visitors
 
             var origColor = _console.ForegroundColor;
             _console.ForegroundColor = ConsoleColor.Green;
-            _console.WriteLine("dependency:");
-            _console.WriteLine($"    name: {dependency.Configuration.Name}");
-            _console.WriteLine($"    dir: {dir}");
+            _console.WriteLine(strings.DEPENDENCY);
+            _console.WriteLine(strings.NAME + dependency.Configuration.Name);
+            _console.WriteLine(strings.DIRECTORY + dir);
             _console.WriteLine();
             _console.ForegroundColor = origColor;
 

--- a/GitDepend/Visitors/ListMergedBranchesVisitor.cs
+++ b/GitDepend/Visitors/ListMergedBranchesVisitor.cs
@@ -2,6 +2,7 @@
 using System.IO.Abstractions;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -43,9 +44,9 @@ namespace GitDepend.Visitors
 
             var origColor = _console.ForegroundColor;
             _console.ForegroundColor = ConsoleColor.Green;
-            _console.WriteLine("dependency:");
-            _console.WriteLine($"    name: {dependency.Configuration.Name}");
-            _console.WriteLine($"    dir: {dir}");
+            _console.WriteLine(strings.DEPENDENCY);
+            _console.WriteLine(strings.NAME + dependency.Configuration.Name);
+            _console.WriteLine(strings.DIRECTORY + dir);
             _console.WriteLine();
             _console.ForegroundColor = origColor;
 

--- a/GitDepend/Visitors/NamedDependenciesVisitor.cs
+++ b/GitDepend/Visitors/NamedDependenciesVisitor.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -73,9 +74,9 @@ namespace GitDepend.Visitors
 
             var origColor = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine("dependency:");
-            Console.WriteLine($"    name: {dependency.Configuration.Name}");
-            Console.WriteLine($"    dir: {dir}");
+            Console.WriteLine(strings.DEPENDENCY);
+            Console.WriteLine(strings.NAME + dependency.Configuration.Name);
+            Console.WriteLine(strings.DIRECTORY + dir);
             Console.WriteLine();
             Console.ForegroundColor = origColor;
 

--- a/GitDepend/Visitors/VerifyCorrectBranchVisitor.cs
+++ b/GitDepend/Visitors/VerifyCorrectBranchVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using GitDepend.Busi;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Visitors
 {
@@ -43,23 +44,23 @@ namespace GitDepend.Visitors
 
             var code = ReturnCode.Success;
 
-            _console.WriteLine("Verifying the checked out branch");
+            _console.WriteLine(strings.VERIFYING_CHECKED_OUT_BRANCH);
 
             if (currBranch != dependency.Branch)
             {
                 var oldColor = _console.ForegroundColor;
                 _console.ForegroundColor = ConsoleColor.Red;
-                _console.WriteLine("Invalid Branch!");
-                _console.WriteLine($"    expected {dependency.Branch} but was {currBranch}");
+                _console.WriteLine(strings.INVALID_BRANCH);
+                _console.WriteLine(strings.EXPECTED_BRANCH_BUT_WAS_BRANCH, dependency.Branch, currBranch);
                 _console.ForegroundColor = oldColor;
 
                 bool goodChoice = false;
                 do
                 {
-                    _console.WriteLine("What should I do?");
-                    _console.WriteLine($"1. Update config to point to {currBranch}");
-                    _console.WriteLine($"2. Switch branch to {dependency.Branch}");
-                    _console.WriteLine("3. Give up. I'll figure it out myself.");
+                    _console.WriteLine(strings.WHAT_SHOULD_I_DO);
+                    _console.WriteLine(strings.UPDATE_CONFIG + currBranch);
+                    _console.WriteLine(strings.SWITCH_BRANCH_OPTION + dependency.Branch);
+                    _console.WriteLine(strings.GIVE_UP_OPTION);
                     _console.Write("> ");
                     var choice = _console.ReadLine();
 
@@ -78,14 +79,14 @@ namespace GitDepend.Visitors
                             code = ReturnCode.InvalidBranchCheckedOut;
                             break;
                         default:
-                            _console.WriteLine("Huh? Try again.");
+                            _console.WriteLine(strings.TRY_AGAIN);
                             break;
                     }
                 } while (!goodChoice);
             }
             else
             {
-                _console.WriteLine("everything looks good.");
+                _console.WriteLine(strings.LOOKS_GOOD);
             }
             _console.WriteLine();
 


### PR DESCRIPTION
Right now we have all the outputs that we've created to be grabbing from the Resx file.

We don't have a way of showing the HelpText out of the `Option` attribute due to the fact the strings are not a const.

Maybe that's a separate issue we could bring out later and see if there's a way around this.