### PR TITLE
issue #167 init now asks for the name

### DIFF
--- a/GitDepend.UnitTests/Commands/InitCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/InitCommandTests.cs
@@ -50,7 +50,9 @@ namespace GitDepend.UnitTests.Commands
 
             int index = 0;
             string[] responses = {
+                "testapp",
                 "buildall.bat",
+                "",
                 "Nuget\\Debug"
             };
             console.Arrange(c => c.ReadLine())
@@ -61,8 +63,10 @@ namespace GitDepend.UnitTests.Commands
             var code = instance.Execute();
             Assert.AreEqual(ReturnCode.Success, code, "Invalid Return Code");
             fileSystem.Assert("WriteAllText should have been caleld");
-            Assert.AreEqual(responses[0], Lib1Config.Build.Script, "Invalid Build Script");
-            Assert.AreEqual(responses[1], Lib1Config.Packages.Directory, "Invalid Packages Directory");
+            Assert.AreEqual(responses[0], Lib1Config.Name, "Invalid Name");
+            Assert.AreEqual(responses[1], Lib1Config.Build.Script, "Invalid Build Script");
+            Assert.AreEqual(responses[2], Lib1Config.Build.Arguments, "Invalid Build Script Arguments");
+            Assert.AreEqual(responses[3], Lib1Config.Packages.Directory, "Invalid Packages Directory");
         }
 
         [Test]
@@ -83,6 +87,8 @@ namespace GitDepend.UnitTests.Commands
 
             int index = 0;
             string[] responses = {
+                "",
+                "",
                 "",
                 ""
             };

--- a/GitDepend.UnitTests/Configuration/BuildTests.cs
+++ b/GitDepend.UnitTests/Configuration/BuildTests.cs
@@ -17,7 +17,7 @@ namespace GitDepend.UnitTests.Configuration
             var build = new Build();
 
             Assert.AreEqual("make.bat", build.Script);
-            Assert.AreEqual(null, build.Arguments);
+            Assert.AreEqual(string.Empty, build.Arguments);
         }
 
         [Test]

--- a/GitDepend.UnitTests/Configuration/GitDependFileTests.cs
+++ b/GitDepend.UnitTests/Configuration/GitDependFileTests.cs
@@ -33,7 +33,8 @@ namespace GitDepend.UnitTests.Configuration
             var expected = "{\r\n" +
                            "  \"name\": \"Lib2\",\r\n" +
                            "  \"build\": {\r\n" +
-                           "    \"script\": \"make.bat\"\r\n" +
+                           "    \"script\": \"make.bat\",\r\n" +
+                           "    \"arguments\": \"\"\r\n" +
                            "  },\r\n" +
                            "  \"packages\": {\r\n" +
                            "    \"dir\": \"artifacts/NuGet/Debug\"\r\n" +

--- a/GitDepend/Commands/InitCommand.cs
+++ b/GitDepend/Commands/InitCommand.cs
@@ -50,8 +50,14 @@ namespace GitDepend.Commands
                 return code;
             }
 
+            var dirName = _fileSystem.Path.GetFileName(dir);
+            _console.Write($"name [{config.Name ?? dirName}]: ");
+            config.Name = ReadLine(config.Name ?? dirName);
+
             _console.Write($"build script [{config.Build.Script}]: ");
             config.Build.Script = ReadLine(config.Build.Script);
+            
+            config.Build.Arguments = ReadLine(config.Build.Arguments);
 
             _console.Write($"artifacts dir [{config.Packages.Directory}]: ");
             config.Packages.Directory = ReadLine(config.Packages.Directory);

--- a/GitDepend/Configuration/Build.cs
+++ b/GitDepend/Configuration/Build.cs
@@ -17,7 +17,7 @@ namespace GitDepend.Configuration
         /// Any script arguments.
         /// </summary>
         [JsonProperty("arguments")]
-        public string Arguments { get; set; }
+        public string Arguments { get; set; } = string.Empty;
 
         #region Overrides of Object
 


### PR DESCRIPTION
Why:

* The init verb was not asking for the name

This change addresses the need by:

* Asking for the name in the InitCommand