### PR TITLE
issue #181 IntegrationTests framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team on the [GitDepend/Lobby][gitter]. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -86,3 +86,4 @@ available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
+[gitter]: https://gitter.im/GitDepend/Lobby

--- a/GitDepend.IntegrationTests/GitDepend.IntegrationTests.csproj
+++ b/GitDepend.IntegrationTests/GitDepend.IntegrationTests.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82997606-9F59-4623-AAE2-4920B2A12777}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitDepend.IntegrationTests</RootNamespace>
+    <AssemblyName>GitDepend.IntegrationTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\IntegrationTests\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\IntegrationTests\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LibGit2Sharp, Version=0.23.1.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.23.1\lib\net40\LibGit2Sharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GitDependExecutionInfo.cs" />
+    <Compile Include="Scenarios\HelpPageScenario.cs" />
+    <Compile Include="TestFixtureBase.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitDepend\GitDepend.csproj">
+      <Project>{43967157-583b-4d9c-a464-92f7159b794c}</Project>
+      <Name>GitDepend</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/GitDepend.IntegrationTests/GitDepend.IntegrationTests.v2.ncrunchproject
+++ b/GitDepend.IntegrationTests/GitDepend.IntegrationTests.v2.ncrunchproject
@@ -1,0 +1,27 @@
+﻿<ProjectConfiguration>
+  <AutoDetectNugetBuildDependencies>true</AutoDetectNugetBuildDependencies>
+  <BuildPriority>1000</BuildPriority>
+  <CopyReferencedAssembliesToWorkspace>false</CopyReferencedAssembliesToWorkspace>
+  <ConsiderInconclusiveTestsAsPassing>false</ConsiderInconclusiveTestsAsPassing>
+  <PreloadReferencedAssemblies>false</PreloadReferencedAssemblies>
+  <AllowDynamicCodeContractChecking>true</AllowDynamicCodeContractChecking>
+  <AllowStaticCodeContractChecking>false</AllowStaticCodeContractChecking>
+  <AllowCodeAnalysis>false</AllowCodeAnalysis>
+  <IgnoreThisComponentCompletely>false</IgnoreThisComponentCompletely>
+  <RunPreBuildEvents>false</RunPreBuildEvents>
+  <RunPostBuildEvents>false</RunPostBuildEvents>
+  <PreviouslyBuiltSuccessfully>true</PreviouslyBuiltSuccessfully>
+  <TrackFileDependencies>false</TrackFileDependencies>
+  <InstrumentAssembly>true</InstrumentAssembly>
+  <PreventSigningOfAssembly>false</PreventSigningOfAssembly>
+  <AnalyseExecutionTimes>true</AnalyseExecutionTimes>
+  <DetectStackOverflow>true</DetectStackOverflow>
+  <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
+  <DefaultTestTimeout>60000</DefaultTestTimeout>
+  <UseBuildConfiguration />
+  <UseBuildPlatform />
+  <ProxyProcessPath />
+  <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
+  <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
+  <BuildProcessArchitecture>x86</BuildProcessArchitecture>
+</ProjectConfiguration>

--- a/GitDepend.IntegrationTests/GitDepend.IntegrationTests.v2.ncrunchproject
+++ b/GitDepend.IntegrationTests/GitDepend.IntegrationTests.v2.ncrunchproject
@@ -7,7 +7,7 @@
   <AllowDynamicCodeContractChecking>true</AllowDynamicCodeContractChecking>
   <AllowStaticCodeContractChecking>false</AllowStaticCodeContractChecking>
   <AllowCodeAnalysis>false</AllowCodeAnalysis>
-  <IgnoreThisComponentCompletely>false</IgnoreThisComponentCompletely>
+  <IgnoreThisComponentCompletely>true</IgnoreThisComponentCompletely>
   <RunPreBuildEvents>false</RunPreBuildEvents>
   <RunPostBuildEvents>false</RunPostBuildEvents>
   <PreviouslyBuiltSuccessfully>true</PreviouslyBuiltSuccessfully>
@@ -18,9 +18,9 @@
   <DetectStackOverflow>true</DetectStackOverflow>
   <IncludeStaticReferencesInWorkspace>true</IncludeStaticReferencesInWorkspace>
   <DefaultTestTimeout>60000</DefaultTestTimeout>
-  <UseBuildConfiguration />
-  <UseBuildPlatform />
-  <ProxyProcessPath />
+  <UseBuildConfiguration></UseBuildConfiguration>
+  <UseBuildPlatform></UseBuildPlatform>
+  <ProxyProcessPath></ProxyProcessPath>
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
   <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
   <BuildProcessArchitecture>x86</BuildProcessArchitecture>

--- a/GitDepend.IntegrationTests/GitDependExecutionInfo.cs
+++ b/GitDepend.IntegrationTests/GitDependExecutionInfo.cs
@@ -1,0 +1,20 @@
+﻿namespace GitDepend.IntegrationTests
+{
+    public class GitDependExecutionInfo
+    {
+        /// <summary>
+        /// The return code of GitDepend.
+        /// </summary>
+        public ReturnCode ReturnCode { get; set; }
+
+        /// <summary>
+        /// The output to standard out.
+        /// </summary>
+        public string StandardOut { get; set; }
+
+        /// <summary>
+        /// The output to standard error.
+        /// </summary>
+        public string StandardError { get; set; }
+    }
+}

--- a/GitDepend.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/GitDepend.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GitDepend.IntegrationTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GitDepend.IntegrationTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("82997606-9f59-4623-aae2-4920b2a12777")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GitDepend.IntegrationTests/Scenarios/HelpPageScenario.cs
+++ b/GitDepend.IntegrationTests/Scenarios/HelpPageScenario.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using LibGit2Sharp;
 using NUnit.Framework;
@@ -36,9 +37,14 @@ namespace GitDepend.IntegrationTests.Scenarios
 
             var info = GitDepend("clone", lib2Dir);
 
+            var lib1Exists = Directory.Exists(lib1Dir);
+            var lib2Exists = Directory.Exists(lib2Dir);
+
+            SafeDeleteDirectory(path);
+
             Assert.AreEqual(ReturnCode.Success, info.ReturnCode);
-            Assert.IsTrue(Directory.Exists(lib2Dir));
-            Assert.IsTrue(Directory.Exists(lib1Dir));
+            Assert.IsTrue(lib1Exists);
+            Assert.IsTrue(lib2Exists);
         }
     }
 }

--- a/GitDepend.IntegrationTests/Scenarios/HelpPageScenario.cs
+++ b/GitDepend.IntegrationTests/Scenarios/HelpPageScenario.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Linq;
+using LibGit2Sharp;
+using NUnit.Framework;
+
+namespace GitDepend.IntegrationTests.Scenarios
+{
+    /// <summary>
+    /// Integration tests that target the help page.
+    /// </summary>
+    public class HelpPageScenario : TestFixtureBase
+    {
+        [Test]
+        public void HelpVerb_Returns_Success()
+        {
+            var info = GitDepend("help");
+
+            Assert.AreEqual(ReturnCode.Success, info.ReturnCode);
+        }
+
+        [Test]
+        public void InvalidVerb_Returns_InvalidCommand()
+        {
+            var info = GitDepend("somebadcommand");
+
+            Assert.AreEqual(ReturnCode.InvalidCommand, info.ReturnCode);
+        }
+
+        [Test]
+        public void CloneVerb_ShouldCloneAllRepos()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var lib2Dir = Path.Combine(path, Lib2Name);
+            var lib1Dir = Path.Combine(path, Lib2Name);
+            Clone(Lib2Url, lib2Dir);
+
+            var info = GitDepend("clone", lib2Dir);
+
+            Assert.AreEqual(ReturnCode.Success, info.ReturnCode);
+            Assert.IsTrue(Directory.Exists(lib2Dir));
+            Assert.IsTrue(Directory.Exists(lib1Dir));
+        }
+    }
+}

--- a/GitDepend.IntegrationTests/TestFixtureBase.cs
+++ b/GitDepend.IntegrationTests/TestFixtureBase.cs
@@ -65,36 +65,38 @@ namespace GitDepend.IntegrationTests
             {
                 UseShellExecute = false,
                 WorkingDirectory = workingDirectory,
-                
+
+                CreateNoWindow = true,
+
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
 
-            var proc = Process.Start(info);
-
-            using (var writer = proc.StandardInput)
-            {
-                foreach (var line in input ?? new string[0])
-                {
-                    writer.WriteLine(line);
-                }
-            }
-
             var executionInfo = new GitDependExecutionInfo();
 
-            using (var reader = proc.StandardOutput)
+            using (var proc = Process.Start(info))
             {
-                executionInfo.StandardOut = reader.ReadToEnd();
-            }
+                using (var writer = proc.StandardInput)
+                {
+                    foreach (var line in input ?? new string[0])
+                    {
+                        writer.WriteLine(line);
+                    }
+                }
 
-            using (var reader = proc.StandardError)
-            {
-                executionInfo.StandardError = reader.ReadToEnd();
-            }
-            proc.WaitForExit();
+                using (var reader = proc.StandardOutput)
+                {
+                    executionInfo.StandardOut = reader.ReadToEnd();
+                }
 
-            executionInfo.ReturnCode = (ReturnCode)proc.ExitCode;
+                using (var reader = proc.StandardError)
+                {
+                    executionInfo.StandardError = reader.ReadToEnd();
+                }
+                proc.WaitForExit();
+                executionInfo.ReturnCode = (ReturnCode)proc.ExitCode;
+            }
 
             return executionInfo;
         }
@@ -118,6 +120,22 @@ namespace GitDepend.IntegrationTests
         protected void Clone(string sourceUrl, string workdirPath, CloneOptions options)
         {
             Repository.Clone(sourceUrl, workdirPath, options);
+        }
+
+        /// <summary>
+        /// Deletes a path without throwing an exception.
+        /// </summary>
+        /// <param name="path">The directory to delete.</param>
+        protected void SafeDeleteDirectory(string path)
+        {
+            try
+            {
+                Directory.Delete(path, true);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
     }
 }

--- a/GitDepend.IntegrationTests/TestFixtureBase.cs
+++ b/GitDepend.IntegrationTests/TestFixtureBase.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.CommandLine;
+using LibGit2Sharp;
+using NUnit.Framework;
+
+namespace GitDepend.IntegrationTests
+{
+    public class TestFixtureBase
+    {
+        protected const string Lib1Name = "Lib1";
+        protected const string Lib1Url = "https://github.com/GitDepend/Lib1.git";
+
+        protected const string Lib2Name = "Lib2";
+        protected const string Lib2Url = "https://github.com/GitDepend/Lib2.git";
+
+        /// <summary>
+        /// Executes GitDepend with the given arguments
+        /// </summary>
+        /// <param name="arguments">The arguments to pass to GitDepend.</param>
+        /// <returns>The <see cref="GitDependExecutionInfo"/> with execution results.</returns>
+        protected GitDependExecutionInfo GitDepend(string arguments)
+        {
+            return GitDepend(arguments, ".");
+        }
+
+        /// <summary>
+        /// Executes GitDepend with the given arguments, and input strings.
+        /// </summary>
+        /// <param name="arguments">The arguments to pass to GitDepend.</param>
+        /// <param name="input">An array of user inputs to feed to standard in.</param>
+        /// <returns>The <see cref="GitDependExecutionInfo"/> with execution results.</returns>
+        protected GitDependExecutionInfo GitDepend(string arguments, string[] input)
+        {
+            return GitDepend(arguments, ".", input);
+        }
+
+        /// <summary>
+        /// Executes GitDepend with the given arguments, and runs in the given working directory.
+        /// </summary>
+        /// <param name="arguments">The arguments to pass to GitDepend.</param>
+        /// <param name="workingDirectory">The working directory for GitDepend.</param>
+        /// <returns>The <see cref="GitDependExecutionInfo"/> with execution results.</returns>
+        protected GitDependExecutionInfo GitDepend(string arguments, string workingDirectory)
+        {
+            return GitDepend(arguments, workingDirectory, new string[0]);
+        }
+
+        /// <summary>
+        /// Executes GitDepend with the given arguments and input strings running in the given working directory.
+        /// </summary>
+        /// <param name="arguments">The arguments to pass to GitDepend.</param>
+        /// <param name="workingDirectory">The working directory for GitDepend.</param>
+        /// <param name="input">An array of user inputs to feed to standard in.</param>
+        /// <returns>The <see cref="GitDependExecutionInfo"/> with execution results.</returns>
+        protected GitDependExecutionInfo GitDepend(string arguments, string workingDirectory, string[] input)
+        {
+            var info = new ProcessStartInfo("GitDepend.exe", arguments)
+            {
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory,
+                
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            var proc = Process.Start(info);
+
+            using (var writer = proc.StandardInput)
+            {
+                foreach (var line in input ?? new string[0])
+                {
+                    writer.WriteLine(line);
+                }
+            }
+
+            var executionInfo = new GitDependExecutionInfo();
+
+            using (var reader = proc.StandardOutput)
+            {
+                executionInfo.StandardOut = reader.ReadToEnd();
+            }
+
+            using (var reader = proc.StandardError)
+            {
+                executionInfo.StandardError = reader.ReadToEnd();
+            }
+            proc.WaitForExit();
+
+            executionInfo.ReturnCode = (ReturnCode)proc.ExitCode;
+
+            return executionInfo;
+        }
+
+        /// <summary>
+        /// Clones a git repository
+        /// </summary>
+        /// <param name="sourceUrl">The url to clone.</param>
+        /// <param name="workdirPath">The directory where the repository should be cloned.</param>
+        protected void Clone(string sourceUrl, string workdirPath)
+        {
+            Repository.Clone(sourceUrl, workdirPath);
+        }
+
+        /// <summary>
+        /// Clones a git repository
+        /// </summary>
+        /// <param name="sourceUrl">The url to clone.</param>
+        /// <param name="workdirPath">The directory where the repository should be cloned.</param>
+        /// <param name="options">The <see cref="CloneOptions"/> that control the clone operation.</param>
+        protected void Clone(string sourceUrl, string workdirPath, CloneOptions options)
+        {
+            Repository.Clone(sourceUrl, workdirPath, options);
+        }
+    }
+}

--- a/GitDepend.IntegrationTests/packages.config
+++ b/GitDepend.IntegrationTests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LibGit2Sharp" version="0.23.1" targetFramework="net461" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.164" targetFramework="net461" />
+  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+</packages>

--- a/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
@@ -91,7 +91,7 @@ namespace GitDepend.UnitTests.Commands
                     {
                         checkArtifacts = true;
                         visitor.ReturnCode = ReturnCode.Success;
-                        ((CheckArtifactsVisitor)visitor).UpToDate = false;
+                        ((CheckArtifactsVisitor)visitor).ProjectsThatNeedNugetUpdate.Add("Lib1");
                         return;
                     }
 

--- a/GitDepend.UnitTests/Visitors/CheckArtifactsVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/CheckArtifactsVisitorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Abstractions;
+﻿using System.Collections.Generic;
+using System.IO.Abstractions;
 using GitDepend.Visitors;
 using NUnit.Framework;
 
@@ -24,7 +25,7 @@ namespace GitDepend.UnitTests.Visitors
         {
             EnsureFiles(_fileSystem, Lib1PackagesDirectory, Lib1Packages);
 
-            var visitor = new CheckArtifactsVisitor();
+            var visitor = new CheckArtifactsVisitor(new List<string>());
             var code = visitor.VisitDependency(Lib1Directory, Lib1Dependency);
 
             Assert.AreEqual(ReturnCode.Success, code);
@@ -33,7 +34,7 @@ namespace GitDepend.UnitTests.Visitors
         [Test]
         public void ArtifactsDontExist_FalseUpToDate()
         {
-            var visitor = new CheckArtifactsVisitor();
+            var visitor = new CheckArtifactsVisitor(new List<string>());
             var code = visitor.VisitDependency(Lib1Directory, Lib1Dependency);
 
             Assert.AreEqual(ReturnCode.Success, code);
@@ -46,7 +47,7 @@ namespace GitDepend.UnitTests.Visitors
         
             const string LOWER_VERSION = "0002";
             EnsureFiles(_fileSystem, Lib1PackagesDirectory, Lib1Packages);
-            var visitor = new CheckArtifactsVisitor();
+            var visitor = new CheckArtifactsVisitor(new List<string>());
             visitor.VisitDependency(Lib1Directory, Lib1Dependency);
             
             _fileSystem.File.WriteAllText(Lib2Directory +  "\\packages.config", CreateNugetFile(LOWER_VERSION));
@@ -62,7 +63,7 @@ namespace GitDepend.UnitTests.Visitors
         {
             const string HIGHER_VERSION = "0481";
             EnsureFiles(_fileSystem, Lib1PackagesDirectory, Lib1Packages);
-            var visitor = new CheckArtifactsVisitor();
+            var visitor = new CheckArtifactsVisitor(new List<string>());
             visitor.VisitDependency(Lib1Directory, Lib1Dependency);
 
             _fileSystem.File.WriteAllText(Lib2Directory + "\\packages.config", CreateNugetFile(HIGHER_VERSION));
@@ -77,7 +78,7 @@ namespace GitDepend.UnitTests.Visitors
         public void ArtifactsFolderMissing_DoesntThrowException_AndMarksOutOfDate_NeedsToBuild()
         {
             _fileSystem.Directory.Delete(Lib1PackagesDirectory + @"..\..\..\..\", true);
-            var visitor = new CheckArtifactsVisitor();
+            var visitor = new CheckArtifactsVisitor(new List<string>());
             var code = visitor.VisitDependency(Lib1Directory, Lib1Dependency);
 
             Assert.AreEqual(ReturnCode.Success, code);

--- a/GitDepend.sln
+++ b/GitDepend.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDepend", "GitDepend\GitD
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDepend.UnitTests", "GitDepend.UnitTests\GitDepend.UnitTests.csproj", "{F4B969F6-51FA-4959-ADF5-BDD74429DF75}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDepend.IntegrationTests", "GitDepend.IntegrationTests\GitDepend.IntegrationTests.csproj", "{82997606-9F59-4623-AAE2-4920B2A12777}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{F4B969F6-51FA-4959-ADF5-BDD74429DF75}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4B969F6-51FA-4959-ADF5-BDD74429DF75}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4B969F6-51FA-4959-ADF5-BDD74429DF75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82997606-9F59-4623-AAE2-4920B2A12777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82997606-9F59-4623-AAE2-4920B2A12777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82997606-9F59-4623-AAE2-4920B2A12777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82997606-9F59-4623-AAE2-4920B2A12777}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GitDepend/CommandLine/UpdateSubOptions.cs
+++ b/GitDepend/CommandLine/UpdateSubOptions.cs
@@ -8,5 +8,11 @@ namespace GitDepend.CommandLine
     /// </summary>
     public class UpdateSubOptions : NamedDependenciesOptions
     {
+        /// <summary>
+        /// Forces the build of all projects, regardless of whether existing packages seem to match
+        /// what is needed.
+        /// </summary>
+        [Option('f', "force", DefaultValue = false, HelpText = "Forces dependencies to build before updating packages.")]
+        public bool Force { get; set; }
     }
 }

--- a/GitDepend/Commands/CommandParser.cs
+++ b/GitDepend/Commands/CommandParser.cs
@@ -20,14 +20,21 @@ namespace GitDepend.Commands
             string invokedVerb = null;
             object invokedVerbInstance = null;
 
-            if (!global::CommandLine.Parser.Default.ParseArgumentsStrict(args, Options.Default,
+            if (!global::CommandLine.Parser.Default.ParseArguments(args, Options.Default,
                 (verb, verbOptions) =>
                 {
                     invokedVerb = verb;
                     invokedVerbInstance = verbOptions;
                 }))
             {
-                Environment.Exit(global::CommandLine.Parser.DefaultExitCodeFail);
+                if (string.Equals(invokedVerb, "help", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    Environment.Exit((int)ReturnCode.Success);
+                }
+                else
+                {
+                    Environment.Exit((int)ReturnCode.InvalidCommand);
+                }
             }
 
             var options = invokedVerbInstance as CommonSubOptions;

--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -54,22 +54,22 @@ namespace GitDepend.Commands
 
             //checkArtifactsVisitor this will check to see if we are up to date with the artifacts.
             _algorithm.Reset();
-            var checkArtifactsVisitor = new CheckArtifactsVisitor();
-            _algorithm.TraverseDependencies(checkArtifactsVisitor, _options.Directory);
+            // var checkArtifactsVisitor = new CheckArtifactsVisitor();
+            // _algorithm.TraverseDependencies(checkArtifactsVisitor, _options.Directory);
 
-            if (checkArtifactsVisitor.ReturnCode == ReturnCode.Success && checkArtifactsVisitor.UpToDate)
-            {
-                _console.WriteLine(strings.PACKAGES_UP_TO_DATE);
-                return ReturnCode.Success;
-            }
-            if(checkArtifactsVisitor.ReturnCode != ReturnCode.Success)
-            {
-                return checkArtifactsVisitor.ReturnCode;
-            }
+            // if (checkArtifactsVisitor.ReturnCode == ReturnCode.Success && checkArtifactsVisitor.UpToDate)
+            // {
+            //     _console.WriteLine(strings.PACKAGES_UP_TO_DATE);
+            //     return ReturnCode.Success;
+            // }
+            // if(checkArtifactsVisitor.ReturnCode != ReturnCode.Success)
+            // {
+            //     return checkArtifactsVisitor.ReturnCode;
+            // }
 
             var needToBuild = new HashSet<string>();
-            needToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
-            needToBuild.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
+            // needToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
+            // needToBuild.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
 
             _console.WriteLine();
             _algorithm.Reset();

--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -54,22 +54,31 @@ namespace GitDepend.Commands
 
             //checkArtifactsVisitor this will check to see if we are up to date with the artifacts.
             _algorithm.Reset();
-            // var checkArtifactsVisitor = new CheckArtifactsVisitor();
-            // _algorithm.TraverseDependencies(checkArtifactsVisitor, _options.Directory);
-
-            // if (checkArtifactsVisitor.ReturnCode == ReturnCode.Success && checkArtifactsVisitor.UpToDate)
-            // {
-            //     _console.WriteLine(strings.PACKAGES_UP_TO_DATE);
-            //     return ReturnCode.Success;
-            // }
-            // if(checkArtifactsVisitor.ReturnCode != ReturnCode.Success)
-            // {
-            //     return checkArtifactsVisitor.ReturnCode;
-            // }
 
             var needToBuild = new HashSet<string>();
-            // needToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
-            // needToBuild.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
+            if (_options.Force)
+            {
+                needToBuild.AddRange(_options.Dependencies);
+            }
+            else
+            {
+                var checkArtifactsVisitor = new CheckArtifactsVisitor(_options.Dependencies);
+                _algorithm.TraverseDependencies(checkArtifactsVisitor, _options.Directory);
+
+                if (checkArtifactsVisitor.ReturnCode == ReturnCode.Success && checkArtifactsVisitor.UpToDate)
+                {
+                    _console.WriteLine(strings.PACKAGES_UP_TO_DATE);
+                    return ReturnCode.Success;
+                }
+
+                if (checkArtifactsVisitor.ReturnCode != ReturnCode.Success)
+                {
+                    return checkArtifactsVisitor.ReturnCode;
+                }
+
+                needToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
+                needToBuild.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
+            }
 
             _console.WriteLine();
             _algorithm.Reset();


### PR DESCRIPTION
Why:

* we need at least some basic integration tests

This change addresses the need by:

* Adding a new project to house integration tests.