### PR TITLE
issue #170  fixes update <name>

### DIFF
--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -54,11 +54,12 @@ namespace GitDepend.Commands
 
             //checkArtifactsVisitor this will check to see if we are up to date with the artifacts.
             _algorithm.Reset();
-
-            var needToBuild = new HashSet<string>();
+            
+            List<string> dependeciesToBuild = new List<string>();
+            List<string> projectsToUpdate = new List<string>();
             if (_options.Force)
             {
-                needToBuild.AddRange(_options.Dependencies);
+                dependeciesToBuild.AddRange(_options.Dependencies);
             }
             else
             {
@@ -76,13 +77,13 @@ namespace GitDepend.Commands
                     return checkArtifactsVisitor.ReturnCode;
                 }
 
-                needToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
-                needToBuild.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
+                dependeciesToBuild.AddRange(checkArtifactsVisitor.DependenciesThatNeedBuilding);
+                projectsToUpdate.AddRange(checkArtifactsVisitor.ProjectsThatNeedNugetUpdate);
             }
 
             _console.WriteLine();
             _algorithm.Reset();
-            var buildAndUpdateVisitor = new BuildAndUpdateDependenciesVisitor(needToBuild.ToList());
+            var buildAndUpdateVisitor = new BuildAndUpdateDependenciesVisitor(dependeciesToBuild, projectsToUpdate);
             _algorithm.TraverseDependencies(buildAndUpdateVisitor, _options.Directory);
 
             if (buildAndUpdateVisitor.ReturnCode == ReturnCode.Success)

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -18,7 +18,8 @@ namespace GitDepend.Visitors
     /// </summary>
     public class BuildAndUpdateDependenciesVisitor : IVisitor
     {
-        private readonly IList<string> _whitelist;
+        private readonly List<string> _dependeciesToBuild;
+        private readonly List<string> _projectsToUpdate;
         private static readonly Regex Pattern = new Regex(@"^(?<id>.*?)\.(?<version>(?:\d\.){2,3}\d(?:-.*?)?)$", RegexOptions.Compiled);
         private readonly IGitDependFileFactory _factory;
         private readonly IGit _git;
@@ -35,10 +36,12 @@ namespace GitDepend.Visitors
         /// <summary>
         /// Creates a new <see cref="BuildAndUpdateDependenciesVisitor"/>
         /// </summary>
-        /// <param name="whitelist">The dependencies to update.</param>
-        public BuildAndUpdateDependenciesVisitor(IList<string> whitelist)
+        /// <param name="dependeciesToBuild">The dependencies to build.</param>
+        /// <param name="projectsToUpdate">The projects to update.</param>
+        public BuildAndUpdateDependenciesVisitor(List<string> dependeciesToBuild, List<string> projectsToUpdate)
         {
-            _whitelist = whitelist;
+            _dependeciesToBuild = dependeciesToBuild;
+            _projectsToUpdate = projectsToUpdate;
             _factory = DependencyInjection.Resolve<IGitDependFileFactory>();
             _git = DependencyInjection.Resolve<IGit>();
             _nuget = DependencyInjection.Resolve<INuget>();
@@ -91,8 +94,8 @@ namespace GitDepend.Visitors
             // If there are specific dependencies specified
             // and this one isn't in the list
             // skip it.
-            if (_whitelist.Any() &&
-                _whitelist.All(d => !string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
+            if (_dependeciesToBuild.Any() &&
+                _dependeciesToBuild.All(d => !string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
             {
                 return ReturnCode.Success;
             }
@@ -159,8 +162,8 @@ namespace GitDepend.Visitors
             // If there are specific dependencies specified
             // and this one isn't in the list
             // skip it.
-            if (_whitelist.Any() &&
-                _whitelist.All(d => !string.Equals(d, config.Name, StringComparison.InvariantCultureIgnoreCase)))
+            if (_projectsToUpdate.Any() &&
+                _projectsToUpdate.All(d => !string.Equals(d, config.Name, StringComparison.InvariantCultureIgnoreCase)))
             {
                 return ReturnCode.Success;
             }
@@ -195,8 +198,8 @@ namespace GitDepend.Visitors
                     // If there are specific dependencies specified
                     // and this one isn't in the list
                     // skip it.
-                    if (_whitelist.Any() &&
-                        _whitelist.All(d => !string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
+                    if (_dependeciesToBuild.Any() &&
+                        _dependeciesToBuild.All(d => !string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         continue;
                     }

--- a/GitDepend/Visitors/CheckArtifactsVisitor.cs
+++ b/GitDepend/Visitors/CheckArtifactsVisitor.cs
@@ -111,7 +111,7 @@ namespace GitDepend.Visitors
             //check only the ones that match
             var misMatching = CheckMatches(neededPackages);
 
-            if (misMatching.Any())
+            if (misMatching.Any() || DependenciesThatNeedBuilding.Any(d => config.Dependencies.Any(d2 => d2.Configuration.Name == d)))
             {
                 ProjectsThatNeedNugetUpdate.Add(config.Name);
             }


### PR DESCRIPTION
Why:

* GitDepend update was not properly updating the named dependency.

This change addresses the need by:

* Marking projects as need to update if any of it's libraries were updated.