### PR TITLE
issue #203 dep init now asks for build args

### DIFF
--- a/GitDepend/Commands/InitCommand.cs
+++ b/GitDepend/Commands/InitCommand.cs
@@ -57,6 +57,7 @@ namespace GitDepend.Commands
             _console.Write($"build script [{config.Build.Script}]: ");
             config.Build.Script = ReadLine(config.Build.Script);
             
+            _console.Write($"args [{config.Build.Arguments}]: ");
             config.Build.Arguments = ReadLine(config.Build.Arguments);
 
             _console.Write($"artifacts dir [{config.Packages.Directory}]: ");


### PR DESCRIPTION
Why:

* dep init was waiting for user input for build args, but never asking
the user for arguments. This was confusing for users.

This change addresses the need by:

* Displaying a message asking for build arguments before waiting for
user input.