### PR TITLE
issue #199 Updating branch command to traverse through dependencies when

### DIFF
--- a/GitDepend.UnitTests/Visitors/CreateBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/CreateBranchVisitorTests.cs
@@ -28,7 +28,7 @@ namespace GitDepend.UnitTests.Visitors
         }
 
         [Test]
-        public void VisitProject_ShouldReturn_Error_WhenCreateBranch_Fails()
+        public void VisitProject_ShouldReturn_Success_WhenCreateBranch_Fails()
         {
             const string BRANCH = "feature/my_branch";
 
@@ -41,7 +41,7 @@ namespace GitDepend.UnitTests.Visitors
             var instance = new CreateBranchVisitor(BRANCH);
             var code = instance.VisitProject(Lib2Directory, Lib2Config);
             git.Assert();
-            Assert.AreEqual(ReturnCode.FailedToRunGitCommand, code, "Invalid Return Code");
+            Assert.AreEqual(ReturnCode.Success, code, "Invalid Return Code");
             Assert.AreEqual(Lib2Directory, git.WorkingDirectory, "Invalid working directory");
         }
 

--- a/GitDepend/Visitors/CreateBranchVisitor.cs
+++ b/GitDepend/Visitors/CreateBranchVisitor.cs
@@ -56,7 +56,12 @@ namespace GitDepend.Visitors
         {
             _console.WriteLine(strings.CREATING_BRANCH_ON_REPONAME, BranchName, config.Name);
             _git.WorkingDirectory = directory;
-            return ReturnCode = _git.CreateBranch(BranchName);
+            var code = _git.CreateBranch(BranchName);
+            if (code == ReturnCode.FailedToRunGitCommand)
+            {
+                return ReturnCode = ReturnCode.Success;
+            }
+            return ReturnCode = code;
         }
 
         #endregion


### PR DESCRIPTION
encountering error.

Why:

* The branch command should continue through all dependencies when
creating a branch

This change addresses the need by:

* Fixing the unit test by expecting success when branch creation fails.
* Updating the visitor to check if it failed to run the git command. If
so, then it returns success to continue processing the rest of the
dependencies