### PR TITLE
issue #207 Forceful delete will traverse dependencies

### DIFF
--- a/GitDepend.UnitTests/Visitors/DeleteBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/DeleteBranchVisitorTests.cs
@@ -46,7 +46,7 @@ namespace GitDepend.UnitTests.Visitors
             var code = instance.VisitProject(Lib2Directory, Lib2Config);
             git.Assert();
 
-            Assert.AreEqual(ReturnCode.FailedToRunGitCommand, code, "Invalid Return Code");
+            Assert.AreEqual(ReturnCode.Success, code, "Invalid Return Code");
             Assert.AreEqual(Lib2Directory, git.WorkingDirectory, "Invalid working directory");
             Assert.AreEqual(BRANCH, instance.BranchName, "Invalid branch name");
             Assert.AreEqual(FORCE, instance.Force, "Invalid force flag");

--- a/GitDepend/Visitors/DeleteBranchVisitor.cs
+++ b/GitDepend/Visitors/DeleteBranchVisitor.cs
@@ -65,7 +65,12 @@ namespace GitDepend.Visitors
                 : $"Deleting the {BranchName} branch from {config.Name}");
 
             _git.WorkingDirectory = directory;
-            return ReturnCode = _git.DeleteBranch(BranchName, Force);
+            var code = _git.DeleteBranch(BranchName, Force);
+            if (code == ReturnCode.FailedToRunGitCommand)
+            {
+                return ReturnCode = ReturnCode.Success;
+            }
+            return ReturnCode = code;
         }
 
         #endregion


### PR DESCRIPTION
Why:

* Currently if it encounters an error it will not continue processing
the rest of the dependencies.

This change addresses the need by:

* If it encounters an error, the visitor will return success to continue
processing
* Fixed the unit test that was checking for an error return code