### PR TITLE
issue #209 Checkout, create new branch will keep processing if error

### DIFF
--- a/GitDepend.UnitTests/Visitors/CheckOutBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/CheckOutBranchVisitorTests.cs
@@ -27,7 +27,7 @@ namespace GitDepend.UnitTests.Visitors
         }
 
         [Test]
-        public void VisitProject_ShouldReturn_Error_WhenCheckout_Fails()
+        public void VisitProject_ShouldReturn_Success_WhenCheckout_Fails()
         {
             const string BRANCH = "hotfix/my_branch";
             const bool CREATE = false;
@@ -42,8 +42,8 @@ namespace GitDepend.UnitTests.Visitors
             var code = instance.VisitProject(Lib2Directory, Lib2Config);
 
             git.Assert();
-            Assert.AreEqual(ReturnCode.FailedToRunGitCommand, code, "Invalid Return Code");
-            Assert.AreEqual(ReturnCode.FailedToRunGitCommand, instance.ReturnCode, "Invalid Return Code");
+            Assert.AreEqual(ReturnCode.Success, code, "Invalid Return Code");
+            Assert.AreEqual(ReturnCode.Success, instance.ReturnCode, "Invalid Return Code");
         }
 
         [Test]

--- a/GitDepend/Visitors/CheckOutBranchVisitor.cs
+++ b/GitDepend/Visitors/CheckOutBranchVisitor.cs
@@ -52,7 +52,12 @@ namespace GitDepend.Visitors
         public ReturnCode VisitProject(string directory, GitDependFile config)
         {
             _git.WorkingDirectory = directory;
-            return ReturnCode = _git.Checkout(_branchName, _createBranch);
+            var code = _git.Checkout(_branchName, _createBranch);
+            if (code == ReturnCode.FailedToRunGitCommand)
+            {
+                return ReturnCode = ReturnCode.Success;
+            }
+            return ReturnCode = code;
         }
 
         #endregion


### PR DESCRIPTION
encountered

Why:

* Currently if you checkout a branch that already exists on any
dependency then the command will fail.

This change addresses the need by:

* Fixing the visitor to not fail when there are errors encountered.