### PR TITLE
issue #211 Update command now works on a clean install

### DIFF
--- a/GitDepend.UnitTests/Visitors/DependencyVisitorAlgorithmTests.cs
+++ b/GitDepend.UnitTests/Visitors/DependencyVisitorAlgorithmTests.cs
@@ -207,7 +207,10 @@ namespace GitDepend.UnitTests.Visitors
                     visitedDependencies.Add(dependency.Directory);
                     return ReturnCode.Success;
                 });
-
+            string outDirectory;
+            ReturnCode returnCode;
+            factory.Arrange(x => x.LoadFromDirectory(Lib1Directory, out outDirectory, out returnCode))
+                .Returns(Lib1Config);
             visitor.Arrange(v => v.VisitProject(Arg.AnyString, Arg.IsAny<GitDependFile>()))
                 .Returns((string directory, GitDependFile config) =>
                 {
@@ -218,15 +221,9 @@ namespace GitDepend.UnitTests.Visitors
                 });
 
             string lib2Dir = PROJECT_DIRECTORY;
-            var dir = Lib2Config.Dependencies.First(d => d.Configuration.Name == "Lib1").Directory;
-            string lib1Dir = fileSystem.Path.GetFullPath(fileSystem.Path.Combine(lib2Dir, dir));
 
             fileSystem.Directory.CreateDirectory(PROJECT_DIRECTORY);
             fileSystem.Directory.CreateDirectory(fileSystem.Path.Combine(PROJECT_DIRECTORY, ".git"));
-
-            ReturnCode lib1Code;
-            factory.Arrange(f => f.LoadFromDirectory(lib1Dir, out lib1Dir, out lib1Code))
-                .Returns(Lib1Config);
 
             ReturnCode lib2Code;
             factory.Arrange(f => f.LoadFromDirectory(lib2Dir, out lib2Dir, out lib2Code))

--- a/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
+++ b/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
@@ -72,7 +72,9 @@ namespace GitDepend.Visitors
 
                     code = _git.Clone(dependency.Url, dependency.Directory, dependency.Branch);
                     _console.WriteLine();
-
+                    string dependencyDirectory;
+                    ReturnCode returnCode;
+                    dependency.Configuration = _factory.LoadFromDirectory(dependency.Directory, out dependencyDirectory, out returnCode);
                     // If something went wrong with git we are done.
                     if (code != ReturnCode.Success)
                     {


### PR DESCRIPTION
Why:

* The clean install was not loading the configuration, because before
the clone, the file didn't exist.

This change addresses the need by:

* Loading the configuration into the dependency.