### PR TITLE
issue #186 Adding a pull verb to the list of commands

### DIFF
--- a/GitDepend.UnitTests/Commands/CommandParserTests.cs
+++ b/GitDepend.UnitTests/Commands/CommandParserTests.cs
@@ -12,6 +12,8 @@ namespace GitDepend.UnitTests.Commands
     [TestFixture]
     public class CommandParserTests : TestFixtureBase
     {
+        private const string InvalidCommand = "Invalid Command";
+
         [Test]
         public void GetCommand_ShouldReturn_InitCommand_WhenInitVerbIsSpecified()
         {
@@ -20,7 +22,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is InitCommand, "Invalid Command");
+            Assert.IsTrue(command is InitCommand, InvalidCommand);
         }
 
         [Test]
@@ -31,7 +33,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is ConfigCommand, "Invalid Command");
+            Assert.IsTrue(command is ConfigCommand, InvalidCommand);
         }
 
         [Test]
@@ -41,7 +43,7 @@ namespace GitDepend.UnitTests.Commands
             var instance = new CommandParser();
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is CleanCommand, "Invalid Command");
+            Assert.IsTrue(command is CleanCommand, InvalidCommand);
         }
 
         [Test]
@@ -52,7 +54,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is CloneCommand, "Invalid Command");
+            Assert.IsTrue(command is CloneCommand, InvalidCommand);
         }
 
         [Test]
@@ -63,7 +65,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is UpdateCommand, "Invalid Command");
+            Assert.IsTrue(command is UpdateCommand, InvalidCommand);
         }
 
         [Test]
@@ -74,7 +76,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is StatusCommand, "Invalid Command");
+            Assert.IsTrue(command is StatusCommand, InvalidCommand);
         }
 
         [Test]
@@ -85,7 +87,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is ListCommand, "Invalid Command");
+            Assert.IsTrue(command is ListCommand, InvalidCommand);
         }
 
         [Test]
@@ -96,7 +98,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is BranchCommand, "Invalid Command");
+            Assert.IsTrue(command is BranchCommand, InvalidCommand);
         }
 
         [Test]
@@ -107,7 +109,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is CheckOutCommand, "Invalid Command");
+            Assert.IsTrue(command is CheckOutCommand, InvalidCommand);
         }
 
         [Test]
@@ -118,7 +120,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is SyncCommand, "Invalid Command");
+            Assert.IsTrue(command is SyncCommand, InvalidCommand);
         }
 
         [Test]
@@ -128,7 +130,7 @@ namespace GitDepend.UnitTests.Commands
             var instance = new CommandParser();
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is AddCommand, "InvalidCommand");
+            Assert.IsTrue(command is AddCommand, InvalidCommand);
         }
 
         [Test]
@@ -139,7 +141,7 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
             
-            Assert.IsTrue(command is RemoveCommand, "Invalid Command");
+            Assert.IsTrue(command is RemoveCommand, InvalidCommand);
         }
 
         [Test]
@@ -150,7 +152,17 @@ namespace GitDepend.UnitTests.Commands
 
             var command = instance.GetCommand(args);
 
-            Assert.IsTrue(command is ManageCommand, "Invalid Command");
+            Assert.IsTrue(command is ManageCommand, InvalidCommand);
+        }
+
+        [Test]
+        public void GetCommand_ShouldReturn_PullCommand_WhenPullVerbIsSpecified()
+        {
+            string[] args = {"pull"};
+            var instance = new CommandParser();
+            var command = instance.GetCommand(args);
+
+            Assert.IsTrue(command is PullCommand, InvalidCommand);
         }
     }
 }

--- a/GitDepend.UnitTests/Commands/PullCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/PullCommandTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.CommandLine;
+using GitDepend.Commands;
+using GitDepend.Visitors;
+using NUnit.Framework;
+using Telerik.JustMock;
+using Telerik.JustMock.Helpers;
+
+namespace GitDepend.UnitTests.Commands
+{
+    [TestFixture]
+    public class PullCommandTests : TestFixtureBase
+    {
+        private IDependencyVisitorAlgorithm _algorithm;
+
+        [SetUp]
+        public void Setup()
+        {
+            _algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
+        }
+
+        [Test]
+        public void PullCommandSucceeds()
+        {
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+                (PullBranchVisitor visitor, string directory) =>
+                {
+                    visitor.ReturnCode = ReturnCode.Success;
+                });
+
+            var options = new PullSubOptions();
+            var command = new PullCommand(options);
+
+            var code = command.Execute();
+
+            Assert.AreEqual(ReturnCode.Success, code);
+        }
+
+        [Test]
+        public void PullCommandFails_WhenOtherReturnCodeReturned()
+        {
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+                (PullBranchVisitor visitor, string directory) =>
+                {
+                    visitor.ReturnCode = ReturnCode.InvalidCommand;
+                });
+
+            var options = new PullSubOptions();
+            var command = new PullCommand(options);
+
+            var code = command.Execute();
+
+            Assert.AreNotEqual(ReturnCode.Success, code);
+        }
+    }
+}

--- a/GitDepend.UnitTests/GitDepend.UnitTests.csproj
+++ b/GitDepend.UnitTests/GitDepend.UnitTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Commands\InitCommandTests.cs" />
     <Compile Include="Commands\ListCommandTests.cs" />
     <Compile Include="Commands\ManageCommandTests.cs" />
+    <Compile Include="Commands\PullCommandTests.cs" />
     <Compile Include="Commands\RemoveCommandTests.cs" />
     <Compile Include="Commands\ShowConfigCommandTests.cs" />
     <Compile Include="Commands\StatusCommandTests.cs" />
@@ -113,6 +114,7 @@
     <Compile Include="Visitors\ListMergedBranchesVisitorTests.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitorTests.cs" />
     <Compile Include="Visitors\NullVisitorTests.cs" />
+    <Compile Include="Visitors\PullBranchVisitorTests.cs" />
     <Compile Include="Visitors\RemoveDependencyVisitorTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
@@ -56,10 +56,15 @@ namespace GitDepend.UnitTests.Visitors
         {
             _git.Arrange(x => x.Pull()).Returns(ReturnCode.InvalidCommand);
 
-            var arguments = new List<string>();
             PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
 
-            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
 
             Assert.AreNotEqual(ReturnCode.Success, returnCode);
         }
@@ -71,7 +76,13 @@ namespace GitDepend.UnitTests.Visitors
 
             List<string> arguments = null;
             var visitor = new PullBranchVisitor(new List<string>());
-            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
 
             Assert.AreEqual(ReturnCode.Success, returnCode);
         }
@@ -81,13 +92,7 @@ namespace GitDepend.UnitTests.Visitors
         {
             List<string> arguments = null;
             var visitor = new PullBranchVisitor(new List<string>());
-            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
-            {
-                Configuration = new GitDependFile()
-                {
-                    Name = "name"
-                }
-            });
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
 
             Assert.AreEqual(ReturnCode.Success, returnCode);
         }

--- a/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
@@ -27,10 +27,10 @@ namespace GitDepend.UnitTests.Visitors
         [Test]
         public void PullBranchVisitor_Succeeds_WhenPullSucceeds()
         {
-            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.Success);
+            _git.Arrange(x => x.Pull()).Returns(ReturnCode.Success);
 
             var arguments = new List<string>();
-            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+            PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
 
             var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
 
@@ -41,10 +41,10 @@ namespace GitDepend.UnitTests.Visitors
         [Test]
         public void PullBranchVisitor_Succeeds_WhenPullFails()
         {
-            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.FailedToRunGitCommand);
+            _git.Arrange(x => x.Pull()).Returns(ReturnCode.FailedToRunGitCommand);
 
             var arguments = new List<string>();
-            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+            PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
 
             var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
 
@@ -54,14 +54,44 @@ namespace GitDepend.UnitTests.Visitors
         [Test]
         public void PullBranchVisitor_Fails_OtherThanFailedToRunGitCommand()
         {
-            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.InvalidCommand);
+            _git.Arrange(x => x.Pull()).Returns(ReturnCode.InvalidCommand);
 
             var arguments = new List<string>();
-            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+            PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
 
             var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
 
             Assert.AreNotEqual(ReturnCode.Success, returnCode);
         }
+
+        [Test]
+        public void PullBranchVisitor_NullArguments_ShouldStillSucceed()
+        {
+            _git.Arrange(x => x.Pull()).Returns(ReturnCode.Success);
+
+            List<string> arguments = null;
+            var visitor = new PullBranchVisitor(new List<string>());
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+        [Test]
+        public void PullBranchVisitor_VisitDependency_ShouldReturnSuccess()
+        {
+            List<string> arguments = null;
+            var visitor = new PullBranchVisitor(new List<string>());
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+
     }
 }

--- a/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
@@ -30,7 +30,7 @@ namespace GitDepend.UnitTests.Visitors
             _git.Arrange(x => x.Pull()).Returns(ReturnCode.Success);
 
             var arguments = new List<string>();
-            PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
+            PullBranchVisitor visitor = new PullBranchVisitor(arguments);
 
             var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
 
@@ -44,9 +44,15 @@ namespace GitDepend.UnitTests.Visitors
             _git.Arrange(x => x.Pull()).Returns(ReturnCode.FailedToRunGitCommand);
 
             var arguments = new List<string>();
-            PullBranchVisitor visitor = new PullBranchVisitor(new List<string>());
+            PullBranchVisitor visitor = new PullBranchVisitor(arguments);
 
-            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
 
             Assert.AreEqual(ReturnCode.Success, returnCode);
         }
@@ -96,7 +102,6 @@ namespace GitDepend.UnitTests.Visitors
 
             Assert.AreEqual(ReturnCode.Success, returnCode);
         }
-
 
     }
 }

--- a/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/PullBranchVisitorTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Busi;
+using GitDepend.Configuration;
+using GitDepend.Visitors;
+using NUnit.Framework;
+using Telerik.JustMock;
+using Telerik.JustMock.Helpers;
+
+namespace GitDepend.UnitTests.Visitors
+{
+    [TestFixture]
+    public class PullBranchVisitorTests : TestFixtureBase
+    {
+        private IGit _git;
+
+        [SetUp]
+        public void Setup()
+        {
+            _git = DependencyInjection.Resolve<IGit>();
+        }
+
+        [Test]
+        public void PullBranchVisitor_Succeeds_WhenPullSucceeds()
+        {
+            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.Success);
+
+            var arguments = new List<string>();
+            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+
+        }
+
+        [Test]
+        public void PullBranchVisitor_Succeeds_WhenPullFails()
+        {
+            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.FailedToRunGitCommand);
+
+            var arguments = new List<string>();
+            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+        [Test]
+        public void PullBranchVisitor_Fails_OtherThanFailedToRunGitCommand()
+        {
+            _git.Arrange(x => x.Pull(Arg.IsAny<IList<string>>())).Returns(ReturnCode.InvalidCommand);
+
+            var arguments = new List<string>();
+            PullBranchVisitor visitor = new PullBranchVisitor(arguments, new List<string>());
+
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreNotEqual(ReturnCode.Success, returnCode);
+        }
+    }
+}

--- a/GitDepend/Busi/Git.cs
+++ b/GitDepend/Busi/Git.cs
@@ -188,17 +188,10 @@ namespace GitDepend.Busi
         /// <summary>
         /// Executes the pull request
         /// </summary>
-        /// <param name="arguments"></param>
         /// <returns></returns>
-        public ReturnCode Pull(IList<string> arguments)
+        public ReturnCode Pull()
         {
-            var builder = new StringBuilder();
-            foreach (var argument in arguments)
-            {
-                builder.Append(argument + " ");
-            }
-
-            var code = ExecuteGitCommand("pull " + builder);
+            var code = ExecuteGitCommand("pull");
 
             return code;
         }

--- a/GitDepend/Busi/Git.cs
+++ b/GitDepend/Busi/Git.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.Abstractions;
+using System.Text;
 
 namespace GitDepend.Busi
 {
@@ -180,6 +182,24 @@ namespace GitDepend.Busi
             var code = ExecuteGitCommand($"commit --file=\"{file}\"");
 
             _fileSystem.File.Delete(file);
+            return code;
+        }
+
+        /// <summary>
+        /// Executes the pull request
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        public ReturnCode Pull(IList<string> arguments)
+        {
+            var builder = new StringBuilder();
+            foreach (var argument in arguments)
+            {
+                builder.Append(argument + " ");
+            }
+
+            var code = ExecuteGitCommand("pull " + builder);
+
             return code;
         }
 

--- a/GitDepend/Busi/IGit.cs
+++ b/GitDepend/Busi/IGit.cs
@@ -97,8 +97,7 @@ namespace GitDepend.Busi
         /// <summary>
         /// Runs the pull command with the arguments provided.
         /// </summary>
-        /// <param name="arguments"></param>
         /// <returns></returns>
-        ReturnCode Pull(IList<string> arguments);
+        ReturnCode Pull();
     }
 }

--- a/GitDepend/Busi/IGit.cs
+++ b/GitDepend/Busi/IGit.cs
@@ -1,4 +1,6 @@
-﻿namespace GitDepend.Busi
+﻿using System.Collections.Generic;
+
+namespace GitDepend.Busi
 {
     /// <summary>
     /// A helper class for dealing with git.exe
@@ -91,5 +93,12 @@
         /// </summary>
         /// <returns></returns>
         ReturnCode Clean(bool dryRun, bool force, bool removeFiles, bool removeDirectories);
+
+        /// <summary>
+        /// Runs the pull command with the arguments provided.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        ReturnCode Pull(IList<string> arguments);
     }
 }

--- a/GitDepend/CommandLine/Options.cs
+++ b/GitDepend/CommandLine/Options.cs
@@ -48,6 +48,9 @@ namespace GitDepend.CommandLine
         [VerbOption(ManageCommand.Name, HelpText = "Manage dependency url, directory, branch in config.")]
         public ManageSubOptions ManageVerb { get; set; } = new ManageSubOptions();
 
+        [VerbOption(PullCommand.Name, HelpText = "Pulls named or all dependencies")]
+        public PullSubOptions PullVerb { get; set; } = new PullSubOptions();
+
         [VerbOption(RemoveCommand.Name, HelpText = "Removes a dependency based on its name.")]
         public RemoveSubOptions RemoveVerb { get; set; } = new RemoveSubOptions();
 

--- a/GitDepend/CommandLine/PullSubOptions.cs
+++ b/GitDepend/CommandLine/PullSubOptions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+
+namespace GitDepend.CommandLine
+{
+    /// <summary>
+    /// These options correspond to the pull command
+    /// </summary>
+    public class PullSubOptions : NamedDependenciesOptions
+    {
+        /// <summary>
+        /// The arguments to be sent to the pull command in git.
+        /// </summary>
+        [Option('p', "argList", HelpText = "Any arguments you would like to give to the pull command.")]
+        public IList<string> PullArguments { get; set; }
+    }
+}

--- a/GitDepend/CommandLine/PullSubOptions.cs
+++ b/GitDepend/CommandLine/PullSubOptions.cs
@@ -12,10 +12,5 @@ namespace GitDepend.CommandLine
     /// </summary>
     public class PullSubOptions : NamedDependenciesOptions
     {
-        /// <summary>
-        /// The arguments to be sent to the pull command in git.
-        /// </summary>
-        [Option('p', "argList", HelpText = "Any arguments you would like to give to the pull command.")]
-        public IList<string> PullArguments { get; set; }
     }
 }

--- a/GitDepend/Commands/CommandParser.cs
+++ b/GitDepend/Commands/CommandParser.cs
@@ -91,6 +91,9 @@ namespace GitDepend.Commands
                 case CleanCommand.Name:
                     command = new CleanCommand(options as CleanSubOptions);
                     break;
+                case PullCommand.Name:
+                    command = new PullCommand(options as PullSubOptions);
+                    break;
             }
 
             return command;

--- a/GitDepend/Commands/PullCommand.cs
+++ b/GitDepend/Commands/PullCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.CommandLine;
+using GitDepend.Visitors;
+
+namespace GitDepend.Commands
+{
+    /// <summary>
+    /// This command will do a git pull on the named dependencies.
+    /// </summary>
+    public class PullCommand : NamedDependenciesCommand<PullSubOptions>
+    {
+        /// <summary>
+        /// Name of the command
+        /// </summary>
+        public const string Name = "pull";
+
+        /// <summary>
+        /// The constructor for the PullCommand.
+        /// </summary>
+        /// <param name="options"></param>
+        public PullCommand(PullSubOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        /// Creates the visitor that will be used to traverse the dependency graph.
+        /// </summary>
+        /// <param name="options">The options for the command.</param>
+        /// <returns></returns>
+        protected override NamedDependenciesVisitor CreateVisitor(PullSubOptions options)
+        {
+            return new PullBranchVisitor(options.PullArguments, options.Dependencies);
+        }
+    }
+}

--- a/GitDepend/Commands/PullCommand.cs
+++ b/GitDepend/Commands/PullCommand.cs
@@ -33,7 +33,7 @@ namespace GitDepend.Commands
         /// <returns></returns>
         protected override NamedDependenciesVisitor CreateVisitor(PullSubOptions options)
         {
-            return new PullBranchVisitor(options.PullArguments, options.Dependencies);
+            return new PullBranchVisitor(options.Dependencies);
         }
     }
 }

--- a/GitDepend/GitDepend.csproj
+++ b/GitDepend/GitDepend.csproj
@@ -117,6 +117,7 @@
     <Compile Include="CommandLine\ListSubOptons.cs" />
     <Compile Include="CommandLine\ManageSubOptions.cs" />
     <Compile Include="CommandLine\NamedDependenciesOptions.cs" />
+    <Compile Include="CommandLine\PullSubOptions.cs" />
     <Compile Include="CommandLine\RemoveSubOptions.cs" />
     <Compile Include="CommandLine\StatusSubOptions.cs" />
     <Compile Include="CommandLine\SyncSubOptions.cs" />
@@ -133,6 +134,7 @@
     <Compile Include="Commands\ListCommand.cs" />
     <Compile Include="Commands\ManageCommand.cs" />
     <Compile Include="Commands\NamedDependenciesCommand.cs" />
+    <Compile Include="Commands\PullCommand.cs" />
     <Compile Include="Commands\RemoveCommand.cs" />
     <Compile Include="Commands\StatusCommand.cs" />
     <Compile Include="Commands\SyncCommand.cs" />
@@ -163,6 +165,7 @@
     <Compile Include="Visitors\CheckOutBranchVisitor.cs" />
     <Compile Include="Visitors\CleanDependencyVisitor.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitor.cs" />
+    <Compile Include="Visitors\PullBranchVisitor.cs" />
     <Compile Include="Visitors\RemoveDependencyVisitor.cs" />
     <Compile Include="Visitors\CreateBranchVisitor.cs" />
     <Compile Include="Visitors\DeleteBranchVisitor.cs" />

--- a/GitDepend/Visitors/PullBranchVisitor.cs
+++ b/GitDepend/Visitors/PullBranchVisitor.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Busi;
+using GitDepend.Configuration;
+
+namespace GitDepend.Visitors
+{
+    /// <summary>
+    /// This visitor goes through each dependency (or named dependencies and pulls with the given arguments.
+    /// </summary>
+    public class PullBranchVisitor : NamedDependenciesVisitor
+    {
+        private IGit _git;
+        private IList<string> _arguments;
+
+        /// <summary>
+        /// This visitor pulls in with the given arguments each directory or the named directories in the whitelist.
+        /// </summary>
+        /// <param name="pullArguments">The arguments to pass to the git pull command.</param>
+        /// <param name="whitelist">The dependencies to visit</param>
+        public PullBranchVisitor(IList<string> pullArguments, IList<string> whitelist) : base(whitelist)
+        {
+            _git = DependencyInjection.Resolve<IGit>();
+            _arguments = pullArguments;
+        }
+
+        /// <summary>
+        /// Provides the custom hook for VisitDependency. This will only be called if the dependency
+        /// was specified in the whitelist.
+        /// </summary>
+        /// <param name="directory">The directory of the project.</param>
+        /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+        /// <returns></returns>
+        protected override ReturnCode OnVisitDependency(string directory, Dependency dependency)
+        {
+            return ReturnCode.Success;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public override ReturnCode VisitProject(string directory, GitDependFile config)
+        {
+            _git.WorkingDirectory = directory;
+            var returnCode = _git.Pull(_arguments);
+            if (returnCode == ReturnCode.FailedToRunGitCommand)
+            {
+                return ReturnCode = ReturnCode.Success;
+            }
+            return ReturnCode = returnCode;
+        }
+    }
+}

--- a/GitDepend/Visitors/PullBranchVisitor.cs
+++ b/GitDepend/Visitors/PullBranchVisitor.cs
@@ -14,17 +14,14 @@ namespace GitDepend.Visitors
     public class PullBranchVisitor : NamedDependenciesVisitor
     {
         private IGit _git;
-        private IList<string> _arguments;
 
         /// <summary>
         /// This visitor pulls in with the given arguments each directory or the named directories in the whitelist.
         /// </summary>
-        /// <param name="pullArguments">The arguments to pass to the git pull command.</param>
         /// <param name="whitelist">The dependencies to visit</param>
-        public PullBranchVisitor(IList<string> pullArguments, IList<string> whitelist) : base(whitelist)
+        public PullBranchVisitor(IList<string> whitelist) : base(whitelist)
         {
             _git = DependencyInjection.Resolve<IGit>();
-            _arguments = pullArguments;
         }
 
         /// <summary>
@@ -46,7 +43,7 @@ namespace GitDepend.Visitors
         public override ReturnCode VisitProject(string directory, GitDependFile config)
         {
             _git.WorkingDirectory = directory;
-            var returnCode = _git.Pull(_arguments);
+            var returnCode = _git.Pull();
             if (returnCode == ReturnCode.FailedToRunGitCommand)
             {
                 return ReturnCode = ReturnCode.Success;

--- a/GitDepend/Visitors/PullBranchVisitor.cs
+++ b/GitDepend/Visitors/PullBranchVisitor.cs
@@ -27,13 +27,13 @@ namespace GitDepend.Visitors
         /// <summary>
         /// Provides the custom hook for VisitDependency. This will only be called if the dependency
         /// was specified in the whitelist.
-        /// </summary>
+        /// </summary>  
         /// <param name="directory">The directory of the project.</param>
         /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
         /// <returns></returns>
         protected override ReturnCode OnVisitDependency(string directory, Dependency dependency)
         {
-            _git.WorkingDirectory = directory;
+            _git.WorkingDirectory = dependency.Directory;
             var returnCode = _git.Pull();
             if (returnCode == ReturnCode.FailedToRunGitCommand)
             {

--- a/GitDepend/Visitors/PullBranchVisitor.cs
+++ b/GitDepend/Visitors/PullBranchVisitor.cs
@@ -33,15 +33,6 @@ namespace GitDepend.Visitors
         /// <returns></returns>
         protected override ReturnCode OnVisitDependency(string directory, Dependency dependency)
         {
-            return ReturnCode.Success;
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns></returns>
-        public override ReturnCode VisitProject(string directory, GitDependFile config)
-        {
             _git.WorkingDirectory = directory;
             var returnCode = _git.Pull();
             if (returnCode == ReturnCode.FailedToRunGitCommand)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -21,6 +21,8 @@ Command Line Options
 
       manage      Manage dependency url, directory, branch in config.
 
+      pull        Pull all or named dependencies
+
       remove      Removes a dependency based on its name.
 
       status      Displays git status on dependencies

--- a/docs/source/usage/pull.rst
+++ b/docs/source/usage/pull.rst
@@ -18,4 +18,8 @@ dep pull [dependencies] [-p pull arguments]
 
 dep pull lib1 -p origin
 
+dep pull -p origin
+
+dep pull
+
 ..

--- a/docs/source/usage/pull.rst
+++ b/docs/source/usage/pull.rst
@@ -1,0 +1,21 @@
+pull
+====
+
+Pulls named or all dependencies
+
+..code-block:: bash
+
+    -p, --arglist       Any arguments you would like to give to the pull command
+
+..
+
+Example
+=======
+
+dep pull [dependencies] [-p pull arguments]
+
+..code-block:: bash
+
+dep pull lib1 -p origin
+
+..


### PR DESCRIPTION
issue #186 Adding a pull verb to the list of commands
Why:

* Currently we don't have support for pulling from named or all
dependencies

This change addresses the need by:

* Adding tests for the new code
* Adding a new visitor to perform the pull operation
* Adding a new command