### PR TITLE
issue #215 Adding required to name on manage command

### DIFF
--- a/GitDepend.UnitTests/Commands/CommandParserTests.cs
+++ b/GitDepend.UnitTests/Commands/CommandParserTests.cs
@@ -145,7 +145,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void GetCommand_ShouldReturn_ManageCommand_WhenManageVerbIsSpecified()
         {
-            string[] args = { "manage"};
+            string[] args = { "manage", "-n", "newdir"};
             var instance = new CommandParser();
 
             var command = instance.GetCommand(args);

--- a/GitDepend/CommandLine/ManageSubOptions.cs
+++ b/GitDepend/CommandLine/ManageSubOptions.cs
@@ -12,7 +12,7 @@ namespace GitDepend.CommandLine
         /// <summary>
         /// The identifier of the dependency to update.
         /// </summary>
-        [Option('n', "name", Required = false, HelpText = "Name of the dependency to manage.")]
+        [Option('n', "name", Required = true, HelpText = "Name of the dependency to manage.")]
         public string Name { get; set; }
         
         /// <summary>

--- a/docs/source/usage/manage.rst
+++ b/docs/source/usage/manage.rst
@@ -5,7 +5,7 @@ Manage dependencies in your current directory
 
 .. code-block:: bash
 
-    -n, --name      Name of the dependency to update
+    -n, --name      Required. Name of the dependency to update
 
     -u, --url       Updates/sets the dependency url
 


### PR DESCRIPTION
Why:

* Currently named dependencies are not required as an argument to the
manage command

This change addresses the need by:

* Requiring the manage command to have the name.