### PR TITLE
issue #218 Adding option for named dependencies

### DIFF
--- a/GitDepend/CommandLine/NamedDependenciesOptions.cs
+++ b/GitDepend/CommandLine/NamedDependenciesOptions.cs
@@ -11,7 +11,7 @@ namespace GitDepend.CommandLine
         /// <summary>
         /// Specifies which dependencies will be affected.
         /// </summary>
-        [ValueList(typeof(List<string>))]
+        [Option("deps", HelpText = "The named dependencies to perform the command on.")]
         public IList<string> Dependencies { get; set; }
     }
 }


### PR DESCRIPTION
Why:

* Currently there is no way to tell a difference between two lists of
arguments.

This change addresses the need by:

* Adding an option for the named dependencies.