### PR TITLE
issue #222 Manage command now returns correct code

### DIFF
--- a/GitDepend.UnitTests/Busi/ReturnCodeExtensionsTests.cs
+++ b/GitDepend.UnitTests/Busi/ReturnCodeExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using GitDepend.Busi;
+using NUnit.Framework;
+
+namespace GitDepend.UnitTests.Busi
+{
+    public class ReturnCodeExtensionsTests
+    {
+
+        [TestCaseSource("testCases")]
+        public void GetResxKey_ShouldSucceed(ReturnCode code, string expectedKey)
+        {
+            var key = ReturnCodeExtensions.GetResxKey(code);
+
+            Assert.AreEqual(expectedKey, key);
+        }
+
+        IEnumerable<TestCaseData> testCases
+        {
+            get
+            {
+                yield return new TestCaseData(ReturnCode.Success, "RET_SUCCESS");
+                yield return new TestCaseData(ReturnCode.GitRepositoryNotFound, "RET_GIT_REPO_NOT_FOUND");
+                yield return new TestCaseData(ReturnCode.FailedToRunGitCommand, "RET_GIT_COMMAND_FAILED");
+                yield return new TestCaseData(ReturnCode.FailedToRunNugetCommand, "RET_NUGET_COMMAND_FAILED");
+                yield return new TestCaseData(ReturnCode.FailedToRunBuildScript, "RET_BUILD_SCRIPT_FAILED");
+                yield return new TestCaseData(ReturnCode.DirectoryDoesNotExist, "RET_DIRECTORY_DOES_NOT_EXIST");
+                yield return new TestCaseData(ReturnCode.CouldNotCreateCacheDirectory, "RET_CREATE_CACHE_DIR_FAILED");
+                yield return new TestCaseData(ReturnCode.InvalidUrlFormat, "RET_INVALID_URI_FORMAT");
+                yield return new TestCaseData(ReturnCode.MissingDependency, "RET_MISSING_DEPENDENCY");
+                yield return new TestCaseData(ReturnCode.InvalidBranchCheckedOut, "RET_INVALID_BRANCH_CHECKED_OUT");
+                yield return new TestCaseData(ReturnCode.DependencyPackagesNotBuilt, "RET_DEPENDENCY_PACKAGES_NOT_BUILT");
+                yield return new TestCaseData(ReturnCode.DependencyPackagesMisMatch, "RET_DEPENDENCY_PACKAGES_MISTMATCH");
+                yield return new TestCaseData(ReturnCode.NameDidNotMatchRequestedDependency, "RET_NAME_DID_NOT_MATCH");
+                yield return new TestCaseData(ReturnCode.DependencyAlreadyExists, "RET_DEPENDENCY_ALREADY_EXISTS");
+                yield return new TestCaseData(ReturnCode.FailedToLocateArtifactsDir, "RET_ARTIFACTS_DIR_NOT_FOUND");
+                yield return new TestCaseData(ReturnCode.InvalidArguments, "RET_INVALID_ARGS");
+                yield return new TestCaseData(ReturnCode.InvalidCommand, "RET_INVALID_COMMAND");
+                yield return new TestCaseData(ReturnCode.UnknownError, "RET_UNKNOWN_ERROR");
+            }
+        }
+    }
+}

--- a/GitDepend.UnitTests/GitDepend.UnitTests.csproj
+++ b/GitDepend.UnitTests/GitDepend.UnitTests.csproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="Busi\GitDependFileFactoryTests.cs" />
     <Compile Include="Busi\GitTests.cs" />
+    <Compile Include="Busi\ReturnCodeExtensionsTests.cs" />
     <Compile Include="Commands\AddCommandTests.cs" />
     <Compile Include="Commands\BranchCommandTests.cs" />
     <Compile Include="Commands\CheckOutCommandTests.cs" />

--- a/GitDepend/Commands/ManageCommand.cs
+++ b/GitDepend/Commands/ManageCommand.cs
@@ -82,9 +82,12 @@ namespace GitDepend.Commands
                     }
                 }
             }
-
-            _fileSystem.File.WriteAllText(_fileSystem.Path.Combine(Options.Directory, "GitDepend.json"), config.ToString());
-            _console.WriteLine(strings.CONFIG_UPDATED);
+            if (updated)
+            {
+                _fileSystem.File.WriteAllText(_fileSystem.Path.Combine(Options.Directory, "GitDepend.json"),
+                    config.ToString());
+                _console.WriteLine(strings.CONFIG_UPDATED);
+            }
             return !updated ? ReturnCode.NameDidNotMatchRequestedDependency : ReturnCode.Success;
         }
     }

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -243,9 +243,9 @@ namespace GitDepend.Resources {
         /// <summary>
         ///   Looks up a localized string similar to The specified artifacts directory could not be found.
         /// </summary>
-        internal static string RET_ARTIFACTS_FIR_NOT_FOUND {
+        internal static string RET_ARTIFACTS_DIR_NOT_FOUND {
             get {
-                return ResourceManager.GetString("RET_ARTIFACTS_FIR_NOT_FOUND", resourceCulture);
+                return ResourceManager.GetString("RET_ARTIFACTS_DIR_NOT_FOUND", resourceCulture);
             }
         }
         
@@ -340,7 +340,7 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Name did not match.
+        ///   Looks up a localized string similar to Named dependency did not match.
         /// </summary>
         internal static string RET_NAME_DID_NOT_MATCH {
             get {

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -205,7 +205,7 @@
     <value>Missing Dependency</value>
   </data>
   <data name="RET_NAME_DID_NOT_MATCH" xml:space="preserve">
-    <value>Name did not match</value>
+    <value>Named dependency did not match</value>
   </data>
   <data name="RET_NUGET_COMMAND_FAILED" xml:space="preserve">
     <value>Failed to execute a nuget command</value>
@@ -252,7 +252,7 @@
   <data name="DIRECTORY_NOT_FOUND" xml:space="preserve">
     <value>Unable to locate {0}</value>
   </data>
-  <data name="RET_ARTIFACTS_FIR_NOT_FOUND" xml:space="preserve">
+  <data name="RET_ARTIFACTS_DIR_NOT_FOUND" xml:space="preserve">
     <value>The specified artifacts directory could not be found</value>
   </data>
 </root>

--- a/GitDepend/ReturnCode.cs
+++ b/GitDepend/ReturnCode.cs
@@ -92,8 +92,8 @@
         /// <summary>
         /// Specifies that the artifacts directory could not be found
         /// </summary>
-        [ResxKey("RET_ARTIFACTS_FIR_NOT_FOUND")]
-        FailedToLocateArtifactsDir = 12,
+        [ResxKey("RET_ARTIFACTS_DIR_NOT_FOUND")]
+        FailedToLocateArtifactsDir = 14,
 
         /// <summary>
         /// Indicates the supplied arguments were invalid.


### PR DESCRIPTION
Why:

* The code being returned was not correct.

This change addresses the need by:

* Added unit tests to make sure the correct return code and key were
matching up.
* Fixing the order of the enumeration