### PR TITLE
issue #227 List will now print out a message as opposed to nothing

### DIFF
--- a/GitDepend/Commands/ListCommand.cs
+++ b/GitDepend/Commands/ListCommand.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
 using GitDepend.Configuration;
+using GitDepend.Resources;
 
 namespace GitDepend.Commands
 {
@@ -62,7 +63,7 @@ namespace GitDepend.Commands
         {
             if (string.IsNullOrEmpty(dependency.Configuration.Name))
             {
-                _console.WriteLine($"{indent}- Dependency in directory: {dependency.Directory} is missing a name, or config file.");
+                _console.WriteLine(string.Format(strings.DEPENDENCY_MISSING_NAME, indent, dependency.Directory));
             }
             else
             {

--- a/GitDepend/Commands/ListCommand.cs
+++ b/GitDepend/Commands/ListCommand.cs
@@ -60,10 +60,17 @@ namespace GitDepend.Commands
 
         private void WriteDependency(Dependency dependency, string indent)
         {
-            _console.WriteLine($"{indent}- {dependency.Configuration.Name}");
-            foreach (var subDependency in dependency.Configuration.Dependencies)
+            if (string.IsNullOrEmpty(dependency.Configuration.Name))
             {
-                WriteDependency(subDependency, indent + "    ");
+                _console.WriteLine($"{indent}- Dependency in directory: {dependency.Directory} is missing a name, or config file.");
+            }
+            else
+            {
+                _console.WriteLine($"{indent}- {dependency.Configuration.Name}");
+                foreach (var subDependency in dependency.Configuration.Dependencies)
+                {
+                    WriteDependency(subDependency, indent + "    ");
+                }
             }
         }
 

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -124,6 +124,15 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &quot;{0}- Dependency in directory: {1} is missing a name, or config file.&quot;.
+        /// </summary>
+        internal static string DEPENDENCY_MISSING_NAME {
+            get {
+                return ResourceManager.GetString("DEPENDENCY_MISSING_NAME", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All dependencies on the correct branch.
         /// </summary>
         internal static string DEPS_CORRECT_BRANCH {

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -141,6 +141,9 @@
   <data name="DEPS_CORRECT_BRANCH" xml:space="preserve">
     <value>All dependencies on the correct branch</value>
   </data>
+  <data name="DEPENDENCY_MISSING_NAME" xml:space="preserve">
+    <value>"{0}- Dependency in directory: {1} is missing a name, or config file."</value>
+  </data>
   <data name="DIRECTORY" xml:space="preserve">
     <value>    dir: </value>
   </data>


### PR DESCRIPTION
Why:

* When list couldn't find a name it would print out a blank name. It
looked odd

This change addresses the need by:

* Printing a message letting them know it couldn't be found