### PR TITLE
Performing fetch on each dependency's directory

### DIFF
--- a/GitDepend/Commands/StatusCommand.cs
+++ b/GitDepend/Commands/StatusCommand.cs
@@ -43,8 +43,7 @@ namespace GitDepend.Commands
             return new DisplayStatusVisitor(options.Dependencies);
         }
 
-        #region Overrides of NamedDependenciesCommand<StatusSubOptions>
-
+       
         /// <summary>
         /// Executes after all dependencies have been visited.
         /// </summary>
@@ -62,8 +61,6 @@ namespace GitDepend.Commands
 
             return _git.Status();
         }
-
-        #endregion
 
         #endregion
     }

--- a/GitDepend/Visitors/DisplayStatusVisitor.cs
+++ b/GitDepend/Visitors/DisplayStatusVisitor.cs
@@ -35,6 +35,7 @@ namespace GitDepend.Visitors
         {
             var path = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(directory, dependency.Directory));
             _git.WorkingDirectory = path;
+            _git.Fetch();
             return ReturnCode = _git.Status();
         }
 


### PR DESCRIPTION
issue #226

Why:

* Currently only fetch was being done on the calling project directory

This change addresses the need by:

* Adding a fetch when going through the dependencies