### PR TITLE
We are now making sure that the build script exists, so it doesn't crash.

### DIFF
--- a/GitDepend.UnitTests/Visitors/BuildAndUpdateDependenciesVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/BuildAndUpdateDependenciesVisitorTests.cs
@@ -46,6 +46,13 @@ namespace GitDepend.UnitTests.Visitors
             factory.Arrange(f => f.LoadFromDirectory(Arg.AnyString, out dir, out loadCode))
                 .Returns(Lib1Config);
 
+            EnsureDirectory(fileSystem, Lib1Directory);
+            EnsureDirectory(fileSystem, Lib2Directory);
+            EnsureFiles(fileSystem, Lib1Directory, new List<string>
+            {
+                "make.bat"
+            });
+
             bool scriptExecuted = false;
             processManager.Arrange(m => m.Start(Arg.IsAny<ProcessStartInfo>()))
                 .Returns((ProcessStartInfo info) =>
@@ -59,7 +66,7 @@ namespace GitDepend.UnitTests.Visitors
                         HasExited = true
                     };
                 });
-
+            
 
             var code = instance.VisitDependency(Lib2Directory, Lib1Dependency);
 

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -268,6 +268,15 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The build script specified could not be found.
+        /// </summary>
+        internal static string RET_BUILD_SCRIPT_NOT_FOUND {
+            get {
+                return ResourceManager.GetString("RET_BUILD_SCRIPT_NOT_FOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to create the nuget cache directory.
         /// </summary>
         internal static string RET_CREATE_CACHE_DIR_FAILED {

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -180,6 +180,9 @@
   <data name="RET_BUILD_SCRIPT_FAILED" xml:space="preserve">
     <value>The build script failed</value>
   </data>
+  <data name="RET_BUILD_SCRIPT_NOT_FOUND" xml:space="preserve">
+    <value>The build script specified could not be found</value>
+  </data>
   <data name="RET_CREATE_CACHE_DIR_FAILED" xml:space="preserve">
     <value>Failed to create the nuget cache directory</value>
   </data>

--- a/GitDepend/ReturnCode.cs
+++ b/GitDepend/ReturnCode.cs
@@ -96,6 +96,12 @@
         FailedToLocateArtifactsDir = 14,
 
         /// <summary>
+        /// Indicates build script in config file could not be found
+        /// </summary>
+        [ResxKey("RET_BUILD_SCRIPT_NOT_FOUND")]
+        BuildScriptNotFound = 16,
+
+        /// <summary>
         /// Indicates the supplied arguments were invalid.
         /// </summary>
         [ResxKey("RET_INVALID_ARGS")]

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -112,6 +112,11 @@ namespace GitDepend.Visitors
             if (_dependeciesToBuild.Any(d => string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
             {
                 var buildScript = _fileSystem.Path.Combine(dependency.Directory, config.Build.Script);
+                if (!_fileSystem.File.Exists(buildScript))
+                {
+                    return ReturnCode.BuildScriptNotFound;
+                }
+
                 var info = new ProcessStartInfo(buildScript, config.Build.Arguments)
                 {
                     WorkingDirectory = dependency.Directory,

--- a/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
+++ b/GitDepend/Visitors/BuildAndUpdateDependenciesVisitor.cs
@@ -111,7 +111,7 @@ namespace GitDepend.Visitors
 
             if (_dependeciesToBuild.Any(d => string.Equals(d, dependency.Configuration.Name, StringComparison.InvariantCultureIgnoreCase)))
             {
-                var buildScript = _fileSystem.Path.Combine(dependency.Directory, config.Build.Script);
+                var buildScript =_fileSystem.Path.GetFullPath(_fileSystem.Path.Combine(directory, dependency.Directory, config.Build.Script));
                 if (!_fileSystem.File.Exists(buildScript))
                 {
                     return ReturnCode.BuildScriptNotFound;


### PR DESCRIPTION
We are now making sure that the build script exists, so it doesn't
crash.

issue #231

Why:

* If there would not be a build script it would throw an error

This change addresses the need by:

* Adding a check to make sure the build script exists.
* Fixing the unit tests that were using the visitor affected