### PR TITLE
Added a log verb to GitDepend

### DIFF
--- a/GitDepend.UnitTests/Commands/LogCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/LogCommandTests.cs
@@ -1,0 +1,55 @@
+﻿using GitDepend.CommandLine;
+using GitDepend.Commands;
+using GitDepend.Visitors;
+using NUnit.Framework;
+using Telerik.JustMock;
+using Telerik.JustMock.Helpers;
+
+namespace GitDepend.UnitTests.Commands
+{
+    [TestFixture]
+    public class LogCommandTests : TestFixtureBase
+    {
+        private IDependencyVisitorAlgorithm _algorithm;
+
+        [SetUp]
+        public void Setup()
+        {
+            _algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
+        }
+
+        [Test]
+        public void LogCommandSucceeds()
+        {
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+                (LogVisitor visitor, string directory) =>
+                {
+                    visitor.ReturnCode = ReturnCode.Success;
+                });
+
+            var options = new LogSubOptions();
+            var command = new LogCommand(options);
+
+            var code = command.Execute();
+
+            Assert.AreEqual(ReturnCode.Success, code);
+        }
+
+        [Test]
+        public void LogCommandFails_WhenOtherReturnCodeReturned()
+        {
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+                (LogVisitor visitor, string directory) =>
+                {
+                    visitor.ReturnCode = ReturnCode.InvalidCommand;
+                });
+
+            var options = new LogSubOptions();
+            var command = new LogCommand(options);
+
+            var code = command.Execute();
+
+            Assert.AreNotEqual(ReturnCode.Success, code);
+        }
+    }
+}

--- a/GitDepend.UnitTests/GitDepend.UnitTests.csproj
+++ b/GitDepend.UnitTests/GitDepend.UnitTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Commands\CommandParserTests.cs" />
     <Compile Include="Commands\InitCommandTests.cs" />
     <Compile Include="Commands\ListCommandTests.cs" />
+    <Compile Include="Commands\LogCommandTests.cs" />
     <Compile Include="Commands\ManageCommandTests.cs" />
     <Compile Include="Commands\PullCommandTests.cs" />
     <Compile Include="Commands\PushCommandTests.cs" />
@@ -114,6 +115,7 @@
     <Compile Include="Visitors\DisplayStatusVisitorTests.cs" />
     <Compile Include="Visitors\ListAllBranchesVisitorTests.cs" />
     <Compile Include="Visitors\ListMergedBranchesVisitorTests.cs" />
+    <Compile Include="Visitors\LogVisitorTests.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitorTests.cs" />
     <Compile Include="Visitors\NullVisitorTests.cs" />
     <Compile Include="Visitors\PullBranchVisitorTests.cs" />

--- a/GitDepend.UnitTests/Visitors/LogVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/LogVisitorTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Busi;
+using GitDepend.Configuration;
+using GitDepend.Visitors;
+using NUnit.Framework;
+using Telerik.JustMock;
+using Telerik.JustMock.Helpers;
+
+namespace GitDepend.UnitTests.Visitors
+{
+    [TestFixture]
+    public class LogVisitorTests : TestFixtureBase
+    {
+        private IGit _git;
+
+        [SetUp]
+        public void Setup()
+        {
+            _git = DependencyInjection.Resolve<IGit>();
+        }
+
+        [Test]
+        public void LogVisitor_Succeeds_WhenPullSucceeds()
+        {
+            _git.Arrange(x => x.Log("")).Returns(ReturnCode.Success);
+
+            var dependencies = new List<string>();
+            LogVisitor visitor = new LogVisitor("", dependencies);
+
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+
+        }
+
+        [Test]
+        public void LogVisitor_Succeeds_WhenPullFails()
+        {
+            _git.Arrange(x => x.Log("")).Returns(ReturnCode.FailedToRunGitCommand);
+
+            var dependencies = new List<string>();
+            LogVisitor visitor = new LogVisitor("", dependencies);
+
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+        [Test]
+        public void LogVisitor_Fails_OtherThanFailedToRunGitCommand()
+        {
+            _git.Arrange(x => x.Log("")).Returns(ReturnCode.InvalidCommand);
+
+            LogVisitor visitor = new LogVisitor("", new List<string>());
+
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
+
+            Assert.AreNotEqual(ReturnCode.Success, returnCode);
+        }
+
+        [Test]
+        public void LogVisitor_NullArguments_ShouldStillSucceed()
+        {
+            _git.Arrange(x => x.Log("")).Returns(ReturnCode.Success);
+
+            List<string> arguments = null;
+            var visitor = new LogVisitor("", new List<string>());
+            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            {
+                Configuration = new GitDependFile()
+                {
+                    Name = "name"
+                }
+            });
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+        [Test]
+        public void LogVisitor_VisitDependency_ShouldReturnSuccess()
+        {
+            List<string> arguments = null;
+            var visitor = new LogVisitor("", new List<string>());
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile());
+
+            Assert.AreEqual(ReturnCode.Success, returnCode);
+        }
+
+    }
+}

--- a/GitDepend/Busi/Git.cs
+++ b/GitDepend/Busi/Git.cs
@@ -208,7 +208,18 @@ namespace GitDepend.Busi
 
             return code;
         }
-        
+
+        /// <summary>
+        /// Executes the log command.
+        /// </summary>
+        /// <returns></returns>
+        public ReturnCode Log(string arguments)
+        {
+            var code = ExecuteGitCommand($"log {arguments}");
+
+            return code;
+        }
+
         private ReturnCode ExecuteGitCommand(string arguments)
         {
             var info = new ProcessStartInfo("git", arguments)

--- a/GitDepend/Busi/IGit.cs
+++ b/GitDepend/Busi/IGit.cs
@@ -105,5 +105,11 @@ namespace GitDepend.Busi
         /// </summary>
         /// <returns></returns>
         ReturnCode Pull(string gitPullArguments);
+
+        /// <summary>
+        /// Runs the log command with the arguments provided.
+        /// </summary>
+        /// <returns></returns>
+        ReturnCode Log(string gitLogArguments);
     }
 }

--- a/GitDepend/CommandLine/LogSubOptions.cs
+++ b/GitDepend/CommandLine/LogSubOptions.cs
@@ -1,0 +1,16 @@
+﻿using CommandLine;
+
+namespace GitDepend.CommandLine
+{
+    /// <summary>
+    /// These options correspond to the log command
+    /// </summary>
+    public class LogSubOptions : NamedDependenciesOptions
+    {
+        /// <summary>
+        /// The arguments to be provided to the git log command
+        /// </summary>
+        [Option("args", Required = false, HelpText = "The arguments to be passed to the log command for each dependancy.")]
+        public string GitArguments { get; set; }
+    }
+}

--- a/GitDepend/CommandLine/Options.cs
+++ b/GitDepend/CommandLine/Options.cs
@@ -39,19 +39,22 @@ namespace GitDepend.CommandLine
         [VerbOption(ConfigCommand.Name, HelpText = "Displays the full configuration file")]
         public ConfigSubOptions ConfigVerb { get; set; } = new ConfigSubOptions();
 
-		[VerbOption(InitCommand.Name, HelpText = "Assists you in creating a GitDepend.json")]
+        [VerbOption(InitCommand.Name, HelpText = "Assists you in creating a GitDepend.json")]
         public InitSubOptions InitVerb { get; set; } = new InitSubOptions();
 
         [VerbOption(ListCommand.Name, HelpText = "Lists all repository dependencies")]
         public ListSubOptons ListVerb { get; set; } = new ListSubOptons();
+
+        [VerbOption(LogCommand.Name, HelpText = "Calls git log on all named dependencies.")]
+        public LogSubOptions LogVerb { get; set; } = new LogSubOptions();
 
         [VerbOption(ManageCommand.Name, HelpText = "Manage dependency url, directory, branch in config.")]
         public ManageSubOptions ManageVerb { get; set; } = new ManageSubOptions();
 
         [VerbOption(PullCommand.Name, HelpText = "Pulls named or all dependencies")]
         public PullSubOptions PullVerb { get; set; } = new PullSubOptions();
-		
-		[VerbOption(PushCommand.Name, HelpText = "Performs a git push on all of the dependencies.")]
+        
+        [VerbOption(PushCommand.Name, HelpText = "Performs a git push on all of the dependencies.")]
         public PushSubOptions PushVerb { get; set; } = new PushSubOptions();
 
         [VerbOption(RemoveCommand.Name, HelpText = "Removes a dependency based on its name.")]

--- a/GitDepend/Commands/CommandParser.cs
+++ b/GitDepend/Commands/CommandParser.cs
@@ -73,6 +73,9 @@ namespace GitDepend.Commands
                 case ListCommand.Name:
                     command = new ListCommand(options as ListSubOptons);
                     break;
+                case LogCommand.Name:
+                    command = new LogCommand(options as LogSubOptions);
+                    break;
                 case ManageCommand.Name:
                     command = new ManageCommand(options as ManageSubOptions);
                     break;

--- a/GitDepend/Commands/LogCommand.cs
+++ b/GitDepend/Commands/LogCommand.cs
@@ -1,0 +1,34 @@
+﻿using GitDepend.CommandLine;
+using GitDepend.Visitors;
+
+namespace GitDepend.Commands
+{
+    /// <summary>
+    /// This command will do a git log on the named dependencies.
+    /// </summary>
+    public class LogCommand : NamedDependenciesCommand<LogSubOptions>
+    {
+        /// <summary>
+        /// Name of the command
+        /// </summary>
+        public const string Name = "log";
+
+        /// <summary>
+        /// The constructor for the LogCommand.
+        /// </summary>
+        /// <param name="options"></param>
+        public LogCommand(LogSubOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        /// Creates the visitor that will be used to traverse the dependency graph.
+        /// </summary>
+        /// <param name="options">The options for the command.</param>
+        /// <returns></returns>
+        protected override NamedDependenciesVisitor CreateVisitor(LogSubOptions options)
+        {
+            return new LogVisitor(options.GitArguments, options.Dependencies);
+        }
+    }
+}

--- a/GitDepend/GitDepend.csproj
+++ b/GitDepend/GitDepend.csproj
@@ -115,6 +115,7 @@
     <Compile Include="CommandLine\ConfigSubOptions.cs" />
     <Compile Include="CommandLine\InitSubOptions.cs" />
     <Compile Include="CommandLine\ListSubOptons.cs" />
+    <Compile Include="CommandLine\LogSubOptions.cs" />
     <Compile Include="CommandLine\ManageSubOptions.cs" />
     <Compile Include="CommandLine\NamedDependenciesOptions.cs" />
     <Compile Include="CommandLine\PullSubOptions.cs" />
@@ -133,6 +134,7 @@
     <Compile Include="Commands\InitCommand.cs" />
     <Compile Include="Commands\ConfigCommand.cs" />
     <Compile Include="Commands\ListCommand.cs" />
+    <Compile Include="Commands\LogCommand.cs" />
     <Compile Include="Commands\ManageCommand.cs" />
     <Compile Include="Commands\NamedDependenciesCommand.cs" />
     <Compile Include="Commands\PullCommand.cs" />
@@ -166,6 +168,7 @@
     <Compile Include="Visitors\CheckArtifactsVisitor.cs" />
     <Compile Include="Visitors\CheckOutBranchVisitor.cs" />
     <Compile Include="Visitors\CleanDependencyVisitor.cs" />
+    <Compile Include="Visitors\LogVisitor.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitor.cs" />
     <Compile Include="Visitors\PullBranchVisitor.cs" />
     <Compile Include="Visitors\PushBranchVisitor.cs" />

--- a/GitDepend/Visitors/LogVisitor.cs
+++ b/GitDepend/Visitors/LogVisitor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Busi;
+using GitDepend.Configuration;
+
+namespace GitDepend.Visitors
+{
+    /// <summary>
+    /// This visitor goes through each dependency (or named dependencies) and calls git log with the given arguments.
+    /// </summary>
+    public class LogVisitor : NamedDependenciesVisitor
+    {
+        private IGit _git;
+        private string _gitArguments;
+
+        /// <summary>
+        /// This visitor calls log with the given arguments each directory or the named directories in the whitelist.
+        /// </summary>
+        /// <param name="gitArguments">The list of arguments to provide to git pull</param>
+        /// <param name="whitelist">The dependencies to visit</param>
+        public LogVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
+        {
+            _git = DependencyInjection.Resolve<IGit>();
+            _gitArguments = gitArguments;
+        }
+
+        /// <summary>
+        /// Provides the custom hook for VisitDependency. This will only be called if the dependency
+        /// was specified in the whitelist.
+        /// </summary>  
+        /// <param name="directory">The directory of the project.</param>
+        /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+        /// <returns></returns>
+        protected override ReturnCode OnVisitDependency(string directory, Dependency dependency)
+        {
+            _git.WorkingDirectory = dependency.Directory;
+            var returnCode = _git.Log(_gitArguments);
+            if (returnCode == ReturnCode.FailedToRunGitCommand)
+            {
+                return ReturnCode = ReturnCode.Success;
+            }
+            return ReturnCode = returnCode;
+        }
+    }
+}


### PR DESCRIPTION
Why:
There is no functionality to pull the git log for the dependency tree.
This change addresses the need by:
Creating a log verb and passing all arguments through to git.