### PR TITLE
Creates a temporary cache folder.

### DIFF
--- a/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
@@ -114,7 +114,8 @@ namespace GitDepend.UnitTests.Commands
                     output.AppendLine(text);
                 });
 
-            var expected = "Updated packages: " + Environment.NewLine +
+            var expected = "Failed to delete the nuget cache directory" + Environment.NewLine +
+                            "Updated packages: " + Environment.NewLine +
                            "    " + string.Join(Environment.NewLine + "    ", packages) + Environment.NewLine +
                            "Update complete!" + Environment.NewLine;
 

--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -82,7 +82,7 @@ namespace GitDepend.Commands
 
             if (!_options.Dry)
             {
-                return buildAndUpdateDependencies(dependeciesToBuild, projectsToUpdate);
+                return BuildAndUpdateDependencies(dependeciesToBuild, projectsToUpdate);
             }
             else
             {
@@ -91,11 +91,19 @@ namespace GitDepend.Commands
             }
         }
 
-        private ReturnCode buildAndUpdateDependencies(List<string> dependeciesToBuild, List<string> projectsToUpdate)
+        private ReturnCode BuildAndUpdateDependencies(List<string> dependeciesToBuild, List<string> projectsToUpdate)
         {
             _algorithm.Reset();
             var buildAndUpdateVisitor = new BuildAndUpdateDependenciesVisitor(dependeciesToBuild, projectsToUpdate);
+            if (buildAndUpdateVisitor.CreateCacheDirectory() != ReturnCode.Success)
+            {
+                return ReturnCode.CouldNotCreateCacheDirectory;
+            }
             _algorithm.TraverseDependencies(buildAndUpdateVisitor, _options.Directory);
+            if (!buildAndUpdateVisitor.DeleteCacheDirectory())
+            {
+                _console.WriteLine(strings.DELETE_CACHE_DIR_FAILED);
+            }
 
             if (buildAndUpdateVisitor.ReturnCode == ReturnCode.Success)
             {

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -115,6 +115,15 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to delete the nuget cache directory.
+        /// </summary>
+        internal static string DELETE_CACHE_DIR_FAILED {
+            get {
+                return ResourceManager.GetString("DELETE_CACHE_DIR_FAILED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dependencies to build:.
         /// </summary>
         internal static string DEPENDENCIES_TO_BUILD {

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -285,4 +285,7 @@
   <data name="PROJECTS_UP_TO_DATE" xml:space="preserve">
     <value>All projects are up to date</value>
   </data>
+  <data name="DELETE_CACHE_DIR_FAILED" xml:space="preserve">
+    <value>Failed to delete the nuget cache directory</value>
+  </data>
 </root>

--- a/GitDepend/ReturnCode.cs
+++ b/GitDepend/ReturnCode.cs
@@ -76,8 +76,8 @@
         /// </summary>
         [ResxKey("RET_DEPENDENCY_PACKAGES_MISTMATCH")]
         DependencyPackagesMisMatch = 11,
-		
-		/// <summary>
+        
+        /// <summary>
         /// The name did not match the requested dependency
         /// </summary>
         [ResxKey("RET_NAME_DID_NOT_MATCH")]
@@ -100,8 +100,8 @@
         /// </summary>
         [ResxKey("RET_DEPEND_FILE_NOT_FOUND")]
         ConfigurationFileDoesNotExist = 15,
-		
-		/// <summary>
+        
+        /// <summary>
         /// Indicates build script in config file could not be found
         /// </summary>
         [ResxKey("RET_BUILD_SCRIPT_NOT_FOUND")]


### PR DESCRIPTION
Why:
GitDepend saves old nuget packages in a cache that is just taking up space.
This change addresses the need by:
Making the cache a random, temporary folder that gets deleted after the command completes.