### PR TITLE
Changed log visitor to implement visit project instead of visit depen…

### DIFF
--- a/GitDepend.UnitTests/Visitors/LogVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/LogVisitorTests.cs
@@ -46,12 +46,9 @@ namespace GitDepend.UnitTests.Visitors
             var dependencies = new List<string>();
             LogVisitor visitor = new LogVisitor("", dependencies);
 
-            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile()
             {
-                Configuration = new GitDependFile()
-                {
-                    Name = "name"
-                }
+                Name = "name"
             });
 
             Assert.AreEqual(ReturnCode.Success, returnCode);
@@ -64,12 +61,9 @@ namespace GitDepend.UnitTests.Visitors
 
             LogVisitor visitor = new LogVisitor("", new List<string>());
 
-            var returnCode = visitor.VisitDependency(Lib1Directory, new Dependency()
+            var returnCode = visitor.VisitProject(Lib1Directory, new GitDependFile()
             {
-                Configuration = new GitDependFile()
-                {
-                    Name = "name"
-                }
+                Name = "name"
             });
 
             Assert.AreNotEqual(ReturnCode.Success, returnCode);

--- a/GitDepend/CommandLine/LogSubOptions.cs
+++ b/GitDepend/CommandLine/LogSubOptions.cs
@@ -10,7 +10,7 @@ namespace GitDepend.CommandLine
         /// <summary>
         /// The arguments to be provided to the git log command
         /// </summary>
-        [Option("args", Required = false, HelpText = "The arguments to be passed to the log command for each dependancy.")]
+        [Option("args", Required = false, HelpText = "The arguments to be passed to the log command for each project.")]
         public string GitArguments { get; set; }
     }
 }

--- a/GitDepend/Commands/LogCommand.cs
+++ b/GitDepend/Commands/LogCommand.cs
@@ -37,18 +37,7 @@ namespace GitDepend.Commands
             var visitor = new LogVisitor(_options.GitArguments, _options.Dependencies);
             _algorithm.TraverseDependencies(visitor, _options.Directory);
 
-            var code = visitor.ReturnCode;
-            if (code == ReturnCode.Success)
-            {
-                var origColor = Console.ForegroundColor;
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine(strings.PROJECT);
-                Console.WriteLine(strings.DIRECTORY + _options.Directory);
-                Console.WriteLine();
-                Console.ForegroundColor = origColor;
-            }
-
-            return code;
+			return visitor.ReturnCode;
         }
     }
 }

--- a/GitDepend/Commands/LogCommand.cs
+++ b/GitDepend/Commands/LogCommand.cs
@@ -1,4 +1,6 @@
-﻿using GitDepend.CommandLine;
+﻿using System;
+using GitDepend.CommandLine;
+using GitDepend.Resources;
 using GitDepend.Visitors;
 
 namespace GitDepend.Commands
@@ -6,29 +8,47 @@ namespace GitDepend.Commands
     /// <summary>
     /// This command will do a git log on the named dependencies.
     /// </summary>
-    public class LogCommand : NamedDependenciesCommand<LogSubOptions>
+    public class LogCommand : ICommand
     {
         /// <summary>
         /// Name of the command
         /// </summary>
         public const string Name = "log";
 
+        private readonly IDependencyVisitorAlgorithm _algorithm;
+        private LogSubOptions _options;
+
         /// <summary>
         /// The constructor for the LogCommand.
         /// </summary>
         /// <param name="options"></param>
-        public LogCommand(LogSubOptions options) : base(options)
+        public LogCommand(LogSubOptions options)
         {
+            _options = options;
+            _algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
         }
 
         /// <summary>
-        /// Creates the visitor that will be used to traverse the dependency graph.
+        /// Executes the log command
         /// </summary>
-        /// <param name="options">The options for the command.</param>
         /// <returns></returns>
-        protected override NamedDependenciesVisitor CreateVisitor(LogSubOptions options)
+        public ReturnCode Execute()
         {
-            return new LogVisitor(options.GitArguments, options.Dependencies);
+            var visitor = new LogVisitor(_options.GitArguments, _options.Dependencies);
+            _algorithm.TraverseDependencies(visitor, _options.Directory);
+
+            var code = visitor.ReturnCode;
+            if (code == ReturnCode.Success)
+            {
+                var origColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine(strings.PROJECT);
+                Console.WriteLine(strings.DIRECTORY + _options.Directory);
+                Console.WriteLine();
+                Console.ForegroundColor = origColor;
+            }
+
+            return code;
         }
     }
 }

--- a/GitDepend/GitDepend.csproj
+++ b/GitDepend/GitDepend.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Visitors\CleanDependencyVisitor.cs" />
     <Compile Include="Visitors\LogVisitor.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitor.cs" />
+    <Compile Include="Visitors\NamedProjectsVisitor.cs" />
     <Compile Include="Visitors\PullBranchVisitor.cs" />
     <Compile Include="Visitors\PushBranchVisitor.cs" />
     <Compile Include="Visitors\RemoveDependencyVisitor.cs" />

--- a/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
+++ b/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
@@ -108,13 +108,13 @@ namespace GitDepend.Visitors
                 {
                     _visitedDependencies.Add(dependency.Directory);
 
-	                if (visitor is NamedDependenciesVisitor)
-	                {
-		                ((NamedDependenciesVisitor)visitor).ParentRepoName = config.Name;
-	                }
+                    if (visitor is NamedDependenciesVisitor)
+                    {
+                        ((NamedDependenciesVisitor)visitor).ParentRepoName = config.Name;
+                    }
 
-	                // Visit the dependency.
-					code = visitor.VisitDependency(dir, dependency);
+                    // Visit the dependency.
+                    code = visitor.VisitDependency(dir, dependency);
 
                     // If something went wrong visiting the dependency we are done.
                     if (code != ReturnCode.Success)

--- a/GitDepend/Visitors/LogVisitor.cs
+++ b/GitDepend/Visitors/LogVisitor.cs
@@ -11,32 +11,57 @@ namespace GitDepend.Visitors
     /// <summary>
     /// This visitor goes through each dependency (or named dependencies) and calls git log with the given arguments.
     /// </summary>
-    public class LogVisitor : NamedDependenciesVisitor
+    public class LogVisitor : IVisitor
     {
         private IGit _git;
         private string _gitArguments;
+        private IList<string> _whitelist;
 
         /// <summary>
         /// This visitor calls log with the given arguments each directory or the named directories in the whitelist.
         /// </summary>
         /// <param name="gitArguments">The list of arguments to provide to git pull</param>
         /// <param name="whitelist">The dependencies to visit</param>
-        public LogVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
+        public LogVisitor(string gitArguments, IList<string> whitelist)
         {
             _git = DependencyInjection.Resolve<IGit>();
             _gitArguments = gitArguments;
+            _whitelist = whitelist;
         }
 
         /// <summary>
-        /// Provides the custom hook for VisitDependency. This will only be called if the dependency
-        /// was specified in the whitelist.
-        /// </summary>  
-        /// <param name="directory">The directory of the project.</param>
-        /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+        /// Return code for the visitor
+        /// </summary>
+        public ReturnCode ReturnCode { get; set; }
+
+        /// <summary>
+        /// This command does nothing in this visitor
+        /// </summary>
+        /// <param name="directory"></param>
+        /// <param name="dependency"></param>
         /// <returns></returns>
-        protected override ReturnCode OnVisitDependency(string directory, Dependency dependency)
+        public ReturnCode VisitDependency(string directory, Dependency dependency)
         {
-            _git.WorkingDirectory = dependency.Directory;
+            return ReturnCode.Success;
+        }
+
+        /// <summary>
+        /// Gets the git log for the project.
+        /// </summary>
+        /// <param name="directory"></param>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public ReturnCode VisitProject(string directory, GitDependFile config)
+        {
+            var shouldExecute = _whitelist.Count == 0 ||
+                               _whitelist.Any(d => string.Equals(d, config.Name, StringComparison.CurrentCultureIgnoreCase));
+
+            if (!shouldExecute)
+            {
+                return ReturnCode.Success;
+            }
+
+            _git.WorkingDirectory = directory;
             var returnCode = _git.Log(_gitArguments);
             if (returnCode == ReturnCode.FailedToRunGitCommand)
             {

--- a/GitDepend/Visitors/LogVisitor.cs
+++ b/GitDepend/Visitors/LogVisitor.cs
@@ -11,38 +11,20 @@ namespace GitDepend.Visitors
     /// <summary>
     /// This visitor goes through each dependency (or named dependencies) and calls git log with the given arguments.
     /// </summary>
-    public class LogVisitor : IVisitor
+    public class LogVisitor : NamedProjectsVisitor
     {
         private IGit _git;
         private string _gitArguments;
-        private IList<string> _whitelist;
 
         /// <summary>
         /// This visitor calls log with the given arguments each directory or the named directories in the whitelist.
         /// </summary>
         /// <param name="gitArguments">The list of arguments to provide to git pull</param>
         /// <param name="whitelist">The dependencies to visit</param>
-        public LogVisitor(string gitArguments, IList<string> whitelist)
+        public LogVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
         {
             _git = DependencyInjection.Resolve<IGit>();
             _gitArguments = gitArguments;
-            _whitelist = whitelist;
-        }
-
-        /// <summary>
-        /// Return code for the visitor
-        /// </summary>
-        public ReturnCode ReturnCode { get; set; }
-
-        /// <summary>
-        /// This command does nothing in this visitor
-        /// </summary>
-        /// <param name="directory"></param>
-        /// <param name="dependency"></param>
-        /// <returns></returns>
-        public ReturnCode VisitDependency(string directory, Dependency dependency)
-        {
-            return ReturnCode.Success;
         }
 
         /// <summary>
@@ -51,16 +33,8 @@ namespace GitDepend.Visitors
         /// <param name="directory"></param>
         /// <param name="config"></param>
         /// <returns></returns>
-        public ReturnCode VisitProject(string directory, GitDependFile config)
+        protected override ReturnCode OnVisitProject(string directory, GitDependFile config)
         {
-            var shouldExecute = _whitelist.Count == 0 ||
-                               _whitelist.Any(d => string.Equals(d, config.Name, StringComparison.CurrentCultureIgnoreCase));
-
-            if (!shouldExecute)
-            {
-                return ReturnCode.Success;
-            }
-
             _git.WorkingDirectory = directory;
             var returnCode = _git.Log(_gitArguments);
             if (returnCode == ReturnCode.FailedToRunGitCommand)

--- a/GitDepend/Visitors/NamedProjectsVisitor.cs
+++ b/GitDepend/Visitors/NamedProjectsVisitor.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Busi;
+using GitDepend.Configuration;
+using GitDepend.Resources;
+
+namespace GitDepend.Visitors
+{
+	/// <summary>
+	/// An implementation of <see cref="IVisitor"/> that only operates on the specified
+	/// projects.
+	/// </summary>
+	public abstract class NamedProjectsVisitor : IVisitor
+	{
+
+		private readonly IList<string> _whitelist;
+
+		/// <summary>
+		/// The <see cref="IConsole"/> to use in this visitor.
+		/// </summary>
+		protected readonly IConsole Console;
+
+		/// <summary>
+		/// The <see cref="IFileSystem"/> object.
+		/// </summary>
+		protected readonly IFileSystem FileSystem;
+
+		/// <summary>
+		/// Creates a new <see cref="NamedProjectsVisitor"/>
+		/// </summary>
+		/// <param name="whitelist">The projects to visit. If this list is null or empty all projects will be visited.</param>
+		protected NamedProjectsVisitor(IList<string> whitelist)
+		{
+			_whitelist = whitelist ?? new List<string>();
+			Console = DependencyInjection.Resolve<IConsole>();
+
+			FileSystem = DependencyInjection.Resolve<IFileSystem>();
+		}
+
+		/// <summary>
+		/// Provides the custom hook for VisitDependency. This will only be called if the dependency
+		/// was specified in the whitelist.
+		/// </summary>
+		/// <param name="directory">The directory of the project.</param>
+		/// <param name="config">The <see cref="GitDependFile"/> to for the project.</param>
+		/// <returns></returns>
+		protected abstract ReturnCode OnVisitProject(string directory, GitDependFile config);
+
+		#region Implementation of IVisitor
+
+		/// <summary>
+		/// The return code
+		/// </summary>
+		public ReturnCode ReturnCode { get; set; }
+
+		/// <summary>
+		/// Name of the repo above the current dependancy
+		/// </summary>
+		public string ParentRepoName { get; set; }
+
+		/// <summary>
+		/// Visits a project dependency.
+		/// </summary>
+		/// <param name="directory">The directory of the project.</param>
+		/// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+		/// <returns>The return code.</returns>
+		public ReturnCode VisitDependency(string directory, Dependency dependency)
+		{
+			return ReturnCode = ReturnCode.Success;
+		}
+
+		/// <summary>
+		/// Visits a project.
+		/// </summary>
+		/// <param name="directory">The directory of the project.</param>
+		/// <param name="config">The <see cref="GitDependFile"/> with project configuration information.</param>
+		/// <returns>The return code.</returns>
+		public virtual ReturnCode VisitProject(string directory, GitDependFile config)
+		{
+			var shouldExecute = _whitelist.Count == 0 ||
+								_whitelist.Any(d => string.Equals(d, config.Name, StringComparison.CurrentCultureIgnoreCase));
+
+			if (!shouldExecute)
+			{
+				return ReturnCode.Success;
+			}
+
+			var dir = FileSystem.Path.GetFullPath(directory);
+
+			var origColor = Console.ForegroundColor;
+			Console.ForegroundColor = ConsoleColor.Green;
+			Console.WriteLine(strings.PROJECT);
+			Console.WriteLine(strings.NAME + config.Name);
+			Console.WriteLine(strings.DIRECTORY + dir);
+			Console.WriteLine();
+			Console.ForegroundColor = origColor;
+
+			return ReturnCode = OnVisitProject(directory, config);
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
…dency.

Why:
Log should be calling VisitProject instead of VisitDependency.
This change addresses the need by:
Changing the functionality to be in VisitProject instead of VisitDependency.