### PR TITLE
Modified clean to pass arguments through to git clean.

### DIFF
--- a/GitDepend.UnitTests/Commands/CleanCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/CleanCommandTests.cs
@@ -31,19 +31,13 @@ namespace GitDepend.UnitTests.Commands
             _badCleanSubOptions = new CleanSubOptions()
             {
                 Directory = "dir",
-                DryRun = false,
-                Force = false,
-                RemoveUntrackedFiles = false,
-                RemoveUntrackedDirectories = false
+                GitArguments = ""
             };
 
             _goodCleanSubOptions = new CleanSubOptions()
             {
                 Directory = "dir",
-                DryRun = true,
-                Force = true,
-                RemoveUntrackedFiles = true,
-                RemoveUntrackedDirectories = true
+				GitArguments = "-nfdx"
             };
             string dir;
             ReturnCode code;
@@ -91,7 +85,7 @@ namespace GitDepend.UnitTests.Commands
         public void CleanCommand_Fails_GitReturnCode_FailedToRun()
         {
             var git = DependencyInjection.Resolve<IGit>();
-            git.Arrange(x => x.Clean(false, false, false, false)).Returns(ReturnCode.FailedToRunGitCommand).MustBeCalled();
+            git.Arrange(x => x.Clean("")).Returns(ReturnCode.FailedToRunGitCommand).MustBeCalled();
             var algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
             algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
                 (IVisitor visitor, string directory) =>
@@ -113,7 +107,7 @@ namespace GitDepend.UnitTests.Commands
         public void CleanCommand_WithProject_Succeeds()
         {
             var git = DependencyInjection.Resolve<IGit>();
-            git.Arrange(x => x.Clean(Arg.AnyBool, Arg.AnyBool, Arg.AnyBool, Arg.AnyBool))
+            git.Arrange(x => x.Clean(""))
                 .Returns(ReturnCode.Success)
                 .MustBeCalled();
 
@@ -130,6 +124,7 @@ namespace GitDepend.UnitTests.Commands
                 Name = "name"
             });
             CleanSubOptions newOptions = _goodCleanSubOptions;
+	        newOptions.GitArguments = "";
             newOptions.Dependencies = new List<string>()
             {
                 "name"

--- a/GitDepend.UnitTests/Commands/CleanCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/CleanCommandTests.cs
@@ -37,7 +37,7 @@ namespace GitDepend.UnitTests.Commands
             _goodCleanSubOptions = new CleanSubOptions()
             {
                 Directory = "dir",
-				GitArguments = "-nfdx"
+                GitArguments = "-nfdx"
             };
             string dir;
             ReturnCode code;
@@ -124,7 +124,7 @@ namespace GitDepend.UnitTests.Commands
                 Name = "name"
             });
             CleanSubOptions newOptions = _goodCleanSubOptions;
-	        newOptions.GitArguments = "";
+            newOptions.GitArguments = "";
             newOptions.Dependencies = new List<string>()
             {
                 "name"

--- a/GitDepend/Busi/Git.cs
+++ b/GitDepend/Busi/Git.cs
@@ -138,12 +138,12 @@ namespace GitDepend.Busi
             }
         }
 
-		/// <summary>
-		/// Cleans the directory.
-		/// </summary>
-		/// <param name="arguments"></param>
-		/// <returns></returns>
-		public ReturnCode Clean(string arguments)
+        /// <summary>
+        /// Cleans the directory.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        public ReturnCode Clean(string arguments)
         {
             return ExecuteGitCommand($"clean {arguments}");
         }

--- a/GitDepend/Busi/Git.cs
+++ b/GitDepend/Busi/Git.cs
@@ -138,34 +138,13 @@ namespace GitDepend.Busi
             }
         }
 
-        /// <summary>
-        /// Cleans the directory.
-        /// </summary>
-        /// <param name="dryRun"></param>
-        /// <param name="force"></param>
-        /// <param name="removeFiles"></param>
-        /// <param name="removeDirectories"></param>
-        /// <returns></returns>
-        public ReturnCode Clean(bool dryRun, bool force, bool removeFiles, bool removeDirectories)
+		/// <summary>
+		/// Cleans the directory.
+		/// </summary>
+		/// <param name="arguments"></param>
+		/// <returns></returns>
+		public ReturnCode Clean(string arguments)
         {
-            string arguments = "-";
-            if (dryRun)
-            {
-                arguments += "n";
-            }
-            if (force)
-            {
-                arguments += "f";
-            }
-            if (removeFiles)
-            {
-                arguments += "x";
-            }
-            if (force)
-            {
-                arguments += "d";
-            }
-
             return ExecuteGitCommand($"clean {arguments}");
         }
 

--- a/GitDepend/Busi/IGit.cs
+++ b/GitDepend/Busi/IGit.cs
@@ -92,7 +92,7 @@ namespace GitDepend.Busi
         /// Cleans the directory.
         /// </summary>
         /// <returns></returns>
-        ReturnCode Clean(bool dryRun, bool force, bool removeFiles, bool removeDirectories);
+        ReturnCode Clean(string gitCleanArguments);
 
         /// <summary>
         /// Performs the push command

--- a/GitDepend/CommandLine/CleanSubOptions.cs
+++ b/GitDepend/CommandLine/CleanSubOptions.cs
@@ -13,37 +13,10 @@ namespace GitDepend.CommandLine
     /// <seealso cref="GitDepend.CommandLine.CommonSubOptions" />
     public class CleanSubOptions : NamedDependenciesOptions
     {
-        /// <summary>
-        /// Tells git to tell you all the things that it will remove
-        /// </summary>
-        [Option('n', DefaultValue = false, HelpText = "Perform a dry run")]
-        public bool DryRun { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="CleanSubOptions"/> is force.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if force; otherwise, <c>false</c>.
-        /// </value>
-        [Option('f', DefaultValue = false, HelpText = "Force -- similar to -f argument in git")]
-        public bool Force { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [remove untracked directories].
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if [remove untracked directories]; otherwise, <c>false</c>.
-        /// </value>
-        [Option('d', DefaultValue = false, HelpText = "Remove untracked directories -- performs -d argument in git")]
-        public bool RemoveUntrackedDirectories { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [remove untracked files].
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if [remove untracked files]; otherwise, <c>false</c>.
-        /// </value>
-        [Option('x', DefaultValue = false, HelpText = "Removes untracked files -- performs -x argument in git")]
-        public bool RemoveUntrackedFiles { get; set; }
-    }
+		/// <summary>
+		/// The arguments to be provided to the git pull command
+		/// </summary>
+		[Option("args", Required = false, HelpText = "The arguments to be passed to the pull command for each dependancy.")]
+		public string GitArguments { get; set; }
+	}
 }

--- a/GitDepend/CommandLine/CleanSubOptions.cs
+++ b/GitDepend/CommandLine/CleanSubOptions.cs
@@ -13,10 +13,10 @@ namespace GitDepend.CommandLine
     /// <seealso cref="GitDepend.CommandLine.CommonSubOptions" />
     public class CleanSubOptions : NamedDependenciesOptions
     {
-		/// <summary>
-		/// The arguments to be provided to the git pull command
-		/// </summary>
-		[Option("args", Required = false, HelpText = "The arguments to be passed to the pull command for each dependancy.")]
-		public string GitArguments { get; set; }
-	}
+        /// <summary>
+        /// The arguments to be provided to the git pull command
+        /// </summary>
+        [Option("args", Required = false, HelpText = "The arguments to be passed to the pull command for each dependancy.")]
+        public string GitArguments { get; set; }
+    }
 }

--- a/GitDepend/Commands/CleanCommand.cs
+++ b/GitDepend/Commands/CleanCommand.cs
@@ -17,6 +17,7 @@ namespace GitDepend.Commands
     {
         private readonly IGit _git;
         private readonly IGitDependFileFactory _factory;
+	    private string _gitArguments;
 
         /// <summary>
         /// The name
@@ -30,6 +31,7 @@ namespace GitDepend.Commands
         {
             _git = DependencyInjection.Resolve<IGit>();
             _factory = DependencyInjection.Resolve<IGitDependFileFactory>();
+	        _gitArguments = options.GitArguments;
         }
 
         /// <summary>
@@ -39,7 +41,7 @@ namespace GitDepend.Commands
         /// <returns></returns>
         protected override NamedDependenciesVisitor CreateVisitor(CleanSubOptions options)
         {
-            return new CleanDependencyVisitor(Options.DryRun, Options.Force, Options.RemoveUntrackedFiles, Options.RemoveUntrackedDirectories, Options.Dependencies);
+            return new CleanDependencyVisitor(Options.GitArguments, Options.Dependencies);
         }
 
 
@@ -67,7 +69,7 @@ namespace GitDepend.Commands
 
         private ReturnCode GitClean(CleanSubOptions options)
         {
-            return _git.Clean(options.DryRun, options.Force, options.RemoveUntrackedFiles, options.RemoveUntrackedDirectories);
+            return _git.Clean(_gitArguments);
         }
     }
 }

--- a/GitDepend/Commands/CleanCommand.cs
+++ b/GitDepend/Commands/CleanCommand.cs
@@ -17,7 +17,7 @@ namespace GitDepend.Commands
     {
         private readonly IGit _git;
         private readonly IGitDependFileFactory _factory;
-	    private string _gitArguments;
+        private string _gitArguments;
 
         /// <summary>
         /// The name
@@ -31,7 +31,7 @@ namespace GitDepend.Commands
         {
             _git = DependencyInjection.Resolve<IGit>();
             _factory = DependencyInjection.Resolve<IGitDependFileFactory>();
-	        _gitArguments = options.GitArguments;
+            _gitArguments = options.GitArguments;
         }
 
         /// <summary>

--- a/GitDepend/Visitors/CleanDependencyVisitor.cs
+++ b/GitDepend/Visitors/CleanDependencyVisitor.cs
@@ -16,31 +16,23 @@ namespace GitDepend.Visitors
     public class CleanDependencyVisitor : NamedDependenciesVisitor
     {
         private readonly IGit _git;
-        private bool _cleanDirectory;
-        private bool _cleanFiles;
-        private bool _force;
-        private bool _dryRun;
+	    private string _gitArguments;
 
         /// <summary>
         /// The name matched
         /// </summary>
         public bool NameMatched = false;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CleanDependencyVisitor" /> class.
-        /// </summary>
-        /// <param name="dryRun">if set to <c>true</c> [dry run].</param>
-        /// <param name="force">if set to <c>true</c> [force].</param>
-        /// <param name="cleanFiles">if set to <c>true</c> [clean files].</param>
-        /// <param name="cleanDirectory">if set to <c>true</c> [clean directory].</param>
-        /// <param name="whitelist">The dependency name to clean.</param>
-        public CleanDependencyVisitor(bool dryRun, bool force, bool cleanFiles, bool cleanDirectory, IList<string> whitelist) : base(whitelist)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CleanDependencyVisitor" /> class.
+		/// </summary>
+		/// <param name="gitArguments">Arguments to pass through to git clean.</param>
+		/// <param name="whitelist">The dependency name to clean.</param>
+		public CleanDependencyVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
         {
             _git = DependencyInjection.Resolve<IGit>();
-            _dryRun = dryRun;
-            _force = force;
-            _cleanFiles = cleanFiles;
-            _cleanDirectory = cleanDirectory;
+	        _gitArguments = gitArguments;
+
         }
 
         /// <summary>
@@ -68,7 +60,7 @@ namespace GitDepend.Visitors
         {
             _git.WorkingDirectory = dependency.Directory;
 
-            return _git.Clean(_dryRun, _force, _cleanFiles, _cleanDirectory);
+            return _git.Clean(_gitArguments);
         }
     }
 }

--- a/GitDepend/Visitors/CleanDependencyVisitor.cs
+++ b/GitDepend/Visitors/CleanDependencyVisitor.cs
@@ -16,22 +16,22 @@ namespace GitDepend.Visitors
     public class CleanDependencyVisitor : NamedDependenciesVisitor
     {
         private readonly IGit _git;
-	    private string _gitArguments;
+        private string _gitArguments;
 
         /// <summary>
         /// The name matched
         /// </summary>
         public bool NameMatched = false;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="CleanDependencyVisitor" /> class.
-		/// </summary>
-		/// <param name="gitArguments">Arguments to pass through to git clean.</param>
-		/// <param name="whitelist">The dependency name to clean.</param>
-		public CleanDependencyVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CleanDependencyVisitor" /> class.
+        /// </summary>
+        /// <param name="gitArguments">Arguments to pass through to git clean.</param>
+        /// <param name="whitelist">The dependency name to clean.</param>
+        public CleanDependencyVisitor(string gitArguments, IList<string> whitelist) : base(whitelist)
         {
             _git = DependencyInjection.Resolve<IGit>();
-	        _gitArguments = gitArguments;
+            _gitArguments = gitArguments;
 
         }
 


### PR DESCRIPTION
Why:
Clean supports four arguments currently. We want to support all arguments.
This change addresses the need by:
Creating a parameter to define what arguments to pass through to the clean.