### PR TITLE
Made a limit to what dependencies a command will execute on.

### DIFF
--- a/GitDepend.UnitTests/Commands/BranchCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/BranchCommandTests.cs
@@ -21,7 +21,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.FailedToRunGitCommand;
@@ -81,7 +81,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var deleteVisitor = visitor as DeleteBranchVisitor;
@@ -112,7 +112,7 @@ namespace GitDepend.UnitTests.Commands
                 BranchName = "feature/test_branch"
             };
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var deleteVisitor = visitor as DeleteBranchVisitor;
@@ -148,7 +148,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var mergedBranchesVisitor = visitor as ListMergedBranchesVisitor;
@@ -171,7 +171,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var mergedBranchesVisitor = visitor as ListMergedBranchesVisitor;
@@ -196,7 +196,7 @@ namespace GitDepend.UnitTests.Commands
 
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var createBranchVisitor = visitor as CreateBranchVisitor;
@@ -222,7 +222,7 @@ namespace GitDepend.UnitTests.Commands
 
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var createBranchVisitor = visitor as CreateBranchVisitor;
@@ -246,7 +246,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var listAllBranchesVisitor = visitor as ListAllBranchesVisitor;
@@ -266,7 +266,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     var listAllBranchesVisitor = visitor as ListAllBranchesVisitor;

--- a/GitDepend.UnitTests/Commands/CheckOutCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/CheckOutCommandTests.cs
@@ -33,7 +33,7 @@ namespace GitDepend.UnitTests.Commands
 
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.FailedToRunGitCommand;
@@ -58,7 +58,7 @@ namespace GitDepend.UnitTests.Commands
 
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;

--- a/GitDepend.UnitTests/Commands/CleanCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/CleanCommandTests.cs
@@ -74,7 +74,7 @@ namespace GitDepend.UnitTests.Commands
         {
             //setup IGit
             var algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead((IVisitor visitor, string directory) =>
+            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead((IVisitor visitor, string directory) =>
             {
                 visitor.ReturnCode = ReturnCode.Success;
             }).MustBeCalled();
@@ -93,7 +93,7 @@ namespace GitDepend.UnitTests.Commands
             var git = DependencyInjection.Resolve<IGit>();
             git.Arrange(x => x.Clean(false, false, false, false)).Returns(ReturnCode.FailedToRunGitCommand).MustBeCalled();
             var algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = visitor.VisitProject(directory, Lib1Config);
@@ -118,7 +118,7 @@ namespace GitDepend.UnitTests.Commands
                 .MustBeCalled();
 
             var algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = visitor.VisitProject(directory, Lib1Config);

--- a/GitDepend.UnitTests/Commands/CloneCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/CloneCommandTests.cs
@@ -21,7 +21,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.FailedToRunGitCommand;
@@ -39,7 +39,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;

--- a/GitDepend.UnitTests/Commands/IncludeCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/IncludeCommandTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using GitDepend.CommandLine;
 using GitDepend.Commands;
 using GitDepend.Visitors;
@@ -13,7 +9,7 @@ using Telerik.JustMock.Helpers;
 namespace GitDepend.UnitTests.Commands
 {
     [TestFixture]
-    public class PushCommandTests : TestFixtureBase
+    public class IncludeCommandTests : TestFixtureBase
     {
         private IDependencyVisitorAlgorithm _algorithm;
 
@@ -24,33 +20,33 @@ namespace GitDepend.UnitTests.Commands
         }
 
         [Test]
-        public void PushCommandSucceeds()
+        public void IncludeCommandSucceeds()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
-                (PushBranchVisitor visitor, string directory) =>
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, true)).DoInstead(
+                (IncludeVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;
                 });
-            var options = new PushSubOptions();
-            var command = new PushCommand(options);
+
+            var options = new IncludeSubOptions();
+            var command = new IncludeCommand(options);
 
             var code = command.Execute();
 
             Assert.AreEqual(ReturnCode.Success, code);
-
         }
 
         [Test]
-        public void PushCommandFails_WhenOtherReturnCodeReturned()
+        public void IncludeCommandFails_WhenOtherReturnCodeReturned()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
-                (PushBranchVisitor visitor, string directory) =>
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, true)).DoInstead(
+                (IncludeVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.InvalidCommand;
                 });
 
-            var options = new PushSubOptions();
-            var command = new PushCommand(options);
+            var options = new IncludeSubOptions();
+            var command = new IncludeCommand(options);
 
             var code = command.Execute();
 

--- a/GitDepend.UnitTests/Commands/LogCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/LogCommandTests.cs
@@ -21,7 +21,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void LogCommandSucceeds()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (LogVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;
@@ -38,7 +38,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void LogCommandFails_WhenOtherReturnCodeReturned()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (LogVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.InvalidCommand;

--- a/GitDepend.UnitTests/Commands/ManageCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/ManageCommandTests.cs
@@ -35,7 +35,7 @@ namespace GitDepend.UnitTests.Commands
             ReturnCode returnCode;
             _fileSystem.Arrange(x => x.Path.Combine(Arg.AnyString, Arg.AnyString)).Returns("C:\\projects\\Lib1").MustBeCalled();
             _fileSystem.Arrange(x => x.Path.GetFullPath("C:\\projects\\Lib1")).Returns("C:\\projects\\Lib1").MustBeCalled();
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (ManageDependenciesVisitor visitor, string directory) =>
                 {
                     visitor.NameMatchingDirectory = Lib1Directory;

--- a/GitDepend.UnitTests/Commands/PullCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/PullCommandTests.cs
@@ -26,7 +26,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void PullCommandSucceeds()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (PullBranchVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;
@@ -43,7 +43,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void PullCommandFails_WhenOtherReturnCodeReturned()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (PullBranchVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.InvalidCommand;

--- a/GitDepend.UnitTests/Commands/RemoveCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/RemoveCommandTests.cs
@@ -41,7 +41,7 @@ namespace GitDepend.UnitTests.Commands
         {
             string dir;
             ReturnCode returnCode;
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (RemoveDependencyVisitor visitor, string directory) =>
                 {
                     visitor.FoundDependencyDirectories = new List<string>(){ "C:\\projects\\Lib1" };
@@ -67,7 +67,7 @@ namespace GitDepend.UnitTests.Commands
         [Test]
         public void Execute_ShouldFail_With_MisnamedDependency()
         {
-            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString)).DoInstead(
+            _algorithm.Arrange(x => x.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false)).DoInstead(
                 (RemoveDependencyVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.NameDidNotMatchRequestedDependency;

--- a/GitDepend.UnitTests/Commands/StatusCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/StatusCommandTests.cs
@@ -21,7 +21,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.FailedToRunGitCommand;
@@ -39,7 +39,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
 
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     visitor.ReturnCode = ReturnCode.Success;

--- a/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
+++ b/GitDepend.UnitTests/Commands/UpdateCommandTests.cs
@@ -21,7 +21,7 @@ namespace GitDepend.UnitTests.Commands
         public void Execute_ReturnsError_WhenVerifyCorrectBranchVisitor_Fails()
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     Assert.IsNotNull(visitor as VerifyCorrectBranchVisitor, "The first visitor should be of type VerifyCorrectBranchVisitor");
@@ -42,7 +42,7 @@ namespace GitDepend.UnitTests.Commands
         {
             bool checkoutCalled = false;
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     if (visitor is VerifyCorrectBranchVisitor)
@@ -77,7 +77,7 @@ namespace GitDepend.UnitTests.Commands
             bool checkoutCalled = false;
             bool checkArtifacts = false;
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     if (visitor is VerifyCorrectBranchVisitor)
@@ -136,7 +136,7 @@ namespace GitDepend.UnitTests.Commands
         public void Execute_ReturnsError_WhenVerifyCorrectBranchDryVisitor_Fails()
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     Assert.IsNotNull(visitor as VerifyCorrectBranchVisitor, "The first visitor should be of type VerifyCorrectBranchDryVisitor");
@@ -160,7 +160,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
             var console = Container.Resolve<IConsole>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
 
@@ -196,7 +196,7 @@ namespace GitDepend.UnitTests.Commands
         {
             var algorithm = Container.Resolve<IDependencyVisitorAlgorithm>();
             var console = Container.Resolve<IConsole>();
-            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString))
+            algorithm.Arrange(a => a.TraverseDependencies(Arg.IsAny<IVisitor>(), Arg.AnyString, false))
                 .DoInstead((IVisitor visitor, string directory) =>
                 {
                     if (visitor is VerifyCorrectBranchVisitor)

--- a/GitDepend.UnitTests/GitDepend.UnitTests.csproj
+++ b/GitDepend.UnitTests/GitDepend.UnitTests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Commands\CleanCommandTests.cs" />
     <Compile Include="Commands\CloneCommandTests.cs" />
     <Compile Include="Commands\CommandParserTests.cs" />
+    <Compile Include="Commands\IncludeCommandTests.cs" />
     <Compile Include="Commands\InitCommandTests.cs" />
     <Compile Include="Commands\ListCommandTests.cs" />
     <Compile Include="Commands\LogCommandTests.cs" />
@@ -113,6 +114,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestFixtureBase.cs" />
     <Compile Include="Visitors\DisplayStatusVisitorTests.cs" />
+    <Compile Include="Visitors\IncludeVisitorTests.cs" />
     <Compile Include="Visitors\ListAllBranchesVisitorTests.cs" />
     <Compile Include="Visitors\ListMergedBranchesVisitorTests.cs" />
     <Compile Include="Visitors\LogVisitorTests.cs" />

--- a/GitDepend.UnitTests/Visitors/DependencyVisitorAlgorithmTests.cs
+++ b/GitDepend.UnitTests/Visitors/DependencyVisitorAlgorithmTests.cs
@@ -184,7 +184,7 @@ namespace GitDepend.UnitTests.Visitors
                 });
 
             instance.TraverseDependencies(visitor, PROJECT_DIRECTORY);
-            Assert.AreEqual(ReturnCode.ConfigurationFileDoesNotExist, visitor.ReturnCode, "Invalid ReturnCode");
+            Assert.AreEqual(ReturnCode.FailedToRunBuildScript, visitor.ReturnCode, "Invalid ReturnCode");
         }
 
         [Test]

--- a/GitDepend/Busi/GitDependFileFactory.cs
+++ b/GitDepend/Busi/GitDependFileFactory.cs
@@ -100,6 +100,30 @@ namespace GitDepend.Busi
             return null;
         }
 
+        /// <summary>
+        /// Finds a GitDepend.json file in the given directory and loads it into memory.
+        /// </summary>
+        /// <param name="directory">The directory to start in.</param>
+        /// <returns>Whether the key file exists</returns>
+        public bool CheckForDependencyInclude(string directory)
+        {
+            if (!_fileSystem.Directory.Exists(directory))
+            {
+                return false;
+            }
+            
+            if (!string.IsNullOrEmpty(directory))
+            {
+                var file = _fileSystem.Path.Combine(directory, ".DepInclude");
+
+                if (_fileSystem.File.Exists(file))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         private bool IsValidUrl(string url)
         {
             return Regex.IsMatch(url, @"^https://.*?$");

--- a/GitDepend/Busi/IGitDependFileFactory.cs
+++ b/GitDepend/Busi/IGitDependFileFactory.cs
@@ -15,5 +15,13 @@ namespace GitDepend.Busi
         /// <param name="code">The return code indicating if the load was successful, or which error occurred.</param>
         /// <returns>A <see cref="GitDependFile"/> or null if none could be loaded.</returns>
         GitDependFile LoadFromDirectory(string directory, out string dir, out ReturnCode code);
+
+        /// <summary>
+        /// Finds a GitDepend.json file in the given directory and loads it into memory.
+        /// </summary>
+        /// <param name="directory">The directory to start in.</param>
+        /// <returns>Whether the key file exists</returns>
+        bool CheckForDependencyInclude(string directory);
+
     }
 }

--- a/GitDepend/CommandLine/IncludeSubOptions.cs
+++ b/GitDepend/CommandLine/IncludeSubOptions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using CommandLine;
+using Newtonsoft.Json;
+
+namespace GitDepend.CommandLine
+{
+    /// <summary>
+    /// The options for the init verb
+    /// </summary>
+    public class IncludeSubOptions : CommonSubOptions
+    {
+        /// <summary>
+        /// The arguments to be provided to the git pull command
+        /// </summary>
+        [Option('c', "clear", DefaultValue = false, HelpText = "Reset stack to include all files.")]
+        public bool Clear { get; set; }
+
+        /// <summary>
+        /// The name of the dependency to include.
+        /// </summary>
+        [ValueList(typeof(List<string>))]
+        public IList<string> DepNames { get; set; }
+    }
+}

--- a/GitDepend/CommandLine/ListSubOptons.cs
+++ b/GitDepend/CommandLine/ListSubOptons.cs
@@ -13,5 +13,11 @@ namespace GitDepend.CommandLine
         /// </summary>
         [Option('v', "verbose", DefaultValue = false, HelpText = "Outputs more information than the default.")]
         public bool Verbose { get; set; }
+
+        /// <summary>
+        /// Flag to output entire list regardless of limit files
+        /// </summary>
+        [Option('a', "all", DefaultValue = false, HelpText = "Outputs more information than the default.")]
+        public bool All { get; set; }
     }
 }

--- a/GitDepend/CommandLine/Options.cs
+++ b/GitDepend/CommandLine/Options.cs
@@ -39,6 +39,9 @@ namespace GitDepend.CommandLine
         [VerbOption(ConfigCommand.Name, HelpText = "Displays the full configuration file")]
         public ConfigSubOptions ConfigVerb { get; set; } = new ConfigSubOptions();
 
+        [VerbOption(IncludeCommand.Name, HelpText = "Assists you in creating a GitDepend.json")]
+        public IncludeSubOptions IncludeVerb { get; set; } = new IncludeSubOptions();
+
         [VerbOption(InitCommand.Name, HelpText = "Assists you in creating a GitDepend.json")]
         public InitSubOptions InitVerb { get; set; } = new InitSubOptions();
 

--- a/GitDepend/Commands/CommandParser.cs
+++ b/GitDepend/Commands/CommandParser.cs
@@ -67,6 +67,9 @@ namespace GitDepend.Commands
                 case ConfigCommand.Name:
                     command = new ConfigCommand(options as ConfigSubOptions);
                     break;
+                case IncludeCommand.Name:
+                    command = new IncludeCommand(options as IncludeSubOptions);
+                    break;
                 case InitCommand.Name:
                     command = new InitCommand(options as InitSubOptions);
                     break;

--- a/GitDepend/Commands/IncludeCommand.cs
+++ b/GitDepend/Commands/IncludeCommand.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO.Abstractions;
+using GitDepend.Busi;
+using GitDepend.CommandLine;
+using GitDepend.Configuration;
+using GitDepend.Resources;
+using GitDepend.Visitors;
+
+namespace GitDepend.Commands
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class IncludeCommand : ICommand
+    {
+        private readonly IncludeSubOptions _options;
+        private readonly IFileSystem _fileSystem;
+        private readonly IGitDependFileFactory _factory;
+        private readonly IDependencyVisitorAlgorithm _algorithm;
+        private readonly IConsole _console;
+
+        /// <summary>
+        /// The name of the verb.
+        /// </summary>
+        public const string Name = "include";
+
+        /// <summary>
+        /// Creates a new <see cref="IncludeCommand"/>
+        /// </summary>
+        /// <param name="options">The <see cref="IncludeSubOptions"/> that configures the command.</param>
+        public IncludeCommand(IncludeSubOptions options)
+        {
+            _options = options;
+            _fileSystem = DependencyInjection.Resolve<IFileSystem>();
+            _factory = DependencyInjection.Resolve<IGitDependFileFactory>();
+            _console = DependencyInjection.Resolve<IConsole>();
+            _algorithm = DependencyInjection.Resolve<IDependencyVisitorAlgorithm>();
+        }
+
+        #region Implementation of ICommand
+
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <returns>The return code.</returns>
+        public ReturnCode Execute()
+        {
+            IVisitor visitor = new IncludeVisitor(_options.DepNames, _options.Clear);
+            _algorithm.TraverseDependencies(visitor, _options.Directory, true);
+
+            if (visitor.ReturnCode == ReturnCode.Success)
+            {
+                _console.WriteLine(strings.FILES_UPDATED);
+            }
+
+            return visitor.ReturnCode;
+        }
+
+        #endregion
+    }
+}

--- a/GitDepend/GitDepend.csproj
+++ b/GitDepend/GitDepend.csproj
@@ -113,6 +113,7 @@
     <Compile Include="CommandLine\CloneSubOptions.cs" />
     <Compile Include="CommandLine\CommonSubOptions.cs" />
     <Compile Include="CommandLine\ConfigSubOptions.cs" />
+    <Compile Include="CommandLine\IncludeSubOptions.cs" />
     <Compile Include="CommandLine\InitSubOptions.cs" />
     <Compile Include="CommandLine\ListSubOptons.cs" />
     <Compile Include="CommandLine\LogSubOptions.cs" />
@@ -131,6 +132,7 @@
     <Compile Include="Commands\CloneCommand.cs" />
     <Compile Include="Commands\CommandParser.cs" />
     <Compile Include="Commands\ICommand.cs" />
+    <Compile Include="Commands\IncludeCommand.cs" />
     <Compile Include="Commands\InitCommand.cs" />
     <Compile Include="Commands\ConfigCommand.cs" />
     <Compile Include="Commands\ListCommand.cs" />
@@ -168,6 +170,7 @@
     <Compile Include="Visitors\CheckArtifactsVisitor.cs" />
     <Compile Include="Visitors\CheckOutBranchVisitor.cs" />
     <Compile Include="Visitors\CleanDependencyVisitor.cs" />
+    <Compile Include="Visitors\IncludeVisitor.cs" />
     <Compile Include="Visitors\LogVisitor.cs" />
     <Compile Include="Visitors\ManageDependenciesVisitor.cs" />
     <Compile Include="Visitors\PullBranchVisitor.cs" />

--- a/GitDepend/Resources/strings.Designer.cs
+++ b/GitDepend/Resources/strings.Designer.cs
@@ -196,6 +196,15 @@ namespace GitDepend.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Includes updated..
+        /// </summary>
+        internal static string FILES_UPDATED {
+            get {
+                return ResourceManager.GetString("FILES_UPDATED", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Need to fix dependancy branch mismatch in {0} for {1}.
         /// </summary>
         internal static string FIX_BRANCH_MISMATCH {

--- a/GitDepend/Resources/strings.resx
+++ b/GitDepend/Resources/strings.resx
@@ -288,4 +288,7 @@
   <data name="DELETE_CACHE_DIR_FAILED" xml:space="preserve">
     <value>Failed to delete the nuget cache directory</value>
   </data>
+  <data name="FILES_UPDATED" xml:space="preserve">
+    <value>Includes updated.</value>
+  </data>
 </root>

--- a/GitDepend/Visitors/IDependencyVisitorAlgorithm.cs
+++ b/GitDepend/Visitors/IDependencyVisitorAlgorithm.cs
@@ -1,4 +1,6 @@
-﻿namespace GitDepend.Visitors
+﻿using System.Collections.Generic;
+
+namespace GitDepend.Visitors
 {
     /// <summary>
     /// An algorithm that traverses a project and all its dependencies.
@@ -10,11 +12,24 @@
         /// </summary>
         /// <param name="visitor">The <see cref="IVisitor"/> that should be called at each dependency and project visit.</param>
         /// <param name="directory">The directory containing a GitDepend.json file.</param>
-        void TraverseDependencies(IVisitor visitor, string directory);
+        /// <param name="ignoreFilterFiles">Whether or not the .DepInclude files should be ignored.</param>
+        void TraverseDependencies(IVisitor visitor, string directory, bool ignoreFilterFiles = false);
 
         /// <summary>
         /// Resets the algorithm to a default state.
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// List of projects to filter on
+        /// </summary>
+        List<string> FilterProjects { get; }
+
+        /// <summary>
+        /// Builds a list of projects that should be included in a filtered run
+        /// </summary>
+        /// <param name="directory">Starting directory of the dependency tree</param>
+        /// <returns></returns>
+        ReturnCode PreVisitDependencies(string directory);
     }
 }

--- a/GitDepend/Visitors/IncludeVisitor.cs
+++ b/GitDepend/Visitors/IncludeVisitor.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GitDepend.Configuration;
+using GitDepend.Resources;
+
+namespace GitDepend.Visitors
+{
+    /// <summary>
+    /// An implementation of <see cref="IVisitor"/> that creates a key include file for a specified dependency.
+    /// </summary>
+    public class IncludeVisitor : IVisitor
+    {
+        private readonly IFileSystem _fileSystem;
+        private IList<string> _projectNames;
+        private bool _clean;
+
+        /// <summary>
+        /// Creates a new <see cref="IncludeVisitor"/>
+        /// </summary>
+        /// <param name="projectNames">The projects to create the key file in.</param>
+        /// /// <param name="clean">Whether or not to remove the key files from the whole dependency stack.</param>
+        public IncludeVisitor(IList<string> projectNames, bool clean)
+        {
+            _projectNames = projectNames;
+            _clean = clean;
+            _fileSystem = DependencyInjection.Resolve<IFileSystem>();
+        }
+
+        #region Implementation of IVisitor
+
+        /// <summary>
+        /// The return code
+        /// </summary>
+        public ReturnCode ReturnCode { get; set; }
+
+        /// <summary>
+        /// Visits a project dependency.
+        /// </summary>
+        /// <param name="directory">The directory of the project.</param>
+        /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+        /// <returns>The return code.</returns>
+        public ReturnCode VisitDependency(string directory, Dependency dependency)
+        {
+            return ReturnCode.Success;
+        }
+
+        /// <summary>
+        /// Visits a project.
+        /// </summary>
+        /// <param name="directory">The directory of the project.</param>
+        /// <param name="config">The <see cref="GitDependFile"/> with project configuration information.</param>
+        /// <returns>The return code.</returns>
+        public ReturnCode VisitProject(string directory, GitDependFile config)
+        {
+            string filePath = _fileSystem.Path.Combine(directory, ".DepInclude");
+            if (_projectNames.Contains(config.Name))
+            {
+                if (_clean)
+                {
+                    if (_fileSystem.File.Exists(filePath))
+                    {
+                        _fileSystem.File.Delete(filePath);
+                    }
+                }
+                else
+                {
+                    _fileSystem.File.WriteAllText(filePath, string.Empty);
+                }
+            }
+            return ReturnCode = ReturnCode.Success;
+        }
+
+        #endregion
+    }
+}

--- a/GitDepend/Visitors/NamedDependenciesVisitor.cs
+++ b/GitDepend/Visitors/NamedDependenciesVisitor.cs
@@ -16,10 +16,10 @@ namespace GitDepend.Visitors
     {
         private readonly IList<string> _whitelist;
 
-		/// <summary>
-		/// The <see cref="IConsole"/> to use in this visitor.
-		/// </summary>
-		protected readonly IConsole Console;
+        /// <summary>
+        /// The <see cref="IConsole"/> to use in this visitor.
+        /// </summary>
+        protected readonly IConsole Console;
 
         /// <summary>
         /// The <see cref="IFileSystem"/> object.
@@ -54,18 +54,18 @@ namespace GitDepend.Visitors
         /// </summary>
         public ReturnCode ReturnCode { get; set; }
 
-		/// <summary>
-		/// Name of the repo above the current dependancy
-		/// </summary>
-		public string ParentRepoName { get; set; }
+        /// <summary>
+        /// Name of the repo above the current dependancy
+        /// </summary>
+        public string ParentRepoName { get; set; }
 
-		/// <summary>
-		/// Visits a project dependency.
-		/// </summary>
-		/// <param name="directory">The directory of the project.</param>
-		/// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
-		/// <returns>The return code.</returns>
-		public ReturnCode VisitDependency(string directory, Dependency dependency)
+        /// <summary>
+        /// Visits a project dependency.
+        /// </summary>
+        /// <param name="directory">The directory of the project.</param>
+        /// <param name="dependency">The <see cref="Dependency"/> to visit.</param>
+        /// <returns>The return code.</returns>
+        public ReturnCode VisitDependency(string directory, Dependency dependency)
         {
             var shouldExecute = _whitelist.Count == 0 ||
                                 _whitelist.Any(d => string.Equals(d, dependency.Configuration.Name, StringComparison.CurrentCultureIgnoreCase));


### PR DESCRIPTION
Why:
Many times, commands don't apply to low level dependencies.
This change addresses the need by:
Adding a key file to filter what projects and dependencies will be visited for each command.